### PR TITLE
abort on errors in subdir builds

### DIFF
--- a/pppd/plugins/Makefile.linux
+++ b/pppd/plugins/Makefile.linux
@@ -27,7 +27,7 @@ include .depend
 endif
 
 all:	$(PLUGINS)
-	for d in $(SUBDIRS); do $(MAKE) $(MFLAGS) -C $$d all; done
+	for d in $(SUBDIRS); do $(MAKE) $(MFLAGS) -C $$d all || exit $$?; done
 
 %.so: %.c
 	$(CC) -o $@ $(LDFLAGS) $(CFLAGS) $^
@@ -37,12 +37,12 @@ VERSION = $(shell awk -F '"' '/VERSION/ { print $$2; }' ../patchlevel.h)
 install: $(PLUGINS)
 	$(INSTALL) -d $(LIBDIR)
 	$(INSTALL) $? $(LIBDIR)
-	for d in $(SUBDIRS); do $(MAKE) $(MFLAGS) -C $$d install; done
+	for d in $(SUBDIRS); do $(MAKE) $(MFLAGS) -C $$d install || exit $$?; done
 
 clean:
 	rm -f *.o *.so *.a
-	for d in $(SUBDIRS); do $(MAKE) $(MFLAGS) -C $$d clean; done
+	for d in $(SUBDIRS); do $(MAKE) $(MFLAGS) -C $$d clean || exit $$?; done
 
 depend:
 	$(CPP) -M $(CFLAGS) *.c >.depend
-	for d in $(SUBDIRS); do $(MAKE) $(MFLAGS) -C $$d depend; done
+	for d in $(SUBDIRS); do $(MAKE) $(MFLAGS) -C $$d depend || exit $$?; done


### PR DESCRIPTION
The current recursive loops do not check the exit status of make
in subdirs which leads to `make` passing even when a subdir failed
to compile or install.

URL: https://bugs.gentoo.org/334727
Signed-off-by: Martin von Gagern <Martin.vGagern@gmx.net>
Signed-off-by: Mike Frysinger <vapier@gentoo.org>