### PR TITLE
Support using OpenSSL to provide DES functions.

### DIFF
--- a/pppd/Makefile.linux
+++ b/pppd/Makefile.linux
@@ -39,6 +39,9 @@ LIBS =
 # MS-CHAP authentication protocol.  Also, edit plugins/radius/Makefile.linux.
 CHAPMS=y
 USE_CRYPT=y
+# Alternatively, if you want to use OpenSSL for DES functions, comment out
+# USE_CRYPT, above, and uncomment this line.
+#USE_OPENSSL=y
 # Don't use MSLANMAN unless you really know what you're doing.
 #MSLANMAN=y
 # Uncomment the next line to include support for MPPE.  CHAPMS (above) must
@@ -131,10 +134,17 @@ LIBS	+= -lutil
 endif
 
 ifdef NEEDDES
+ifdef USE_OPENSSL
+CFLAGS   += -DUSE_OPENSSL=1
+LIBS     += -lcrypto
+else
 ifndef USE_CRYPT
-LIBS     += -ldes $(LIBS)
+CFLAGS   += -DUSE_LIBDES=1
+LIBS     += -ldes
 else
 CFLAGS   += -DUSE_CRYPT=1
+LIBS     += -lcrypt
+endif
 endif
 PPPDOBJS += pppcrypt.o
 HEADERS += pppcrypt.h

--- a/pppd/pppcrypt.h
+++ b/pppd/pppcrypt.h
@@ -33,14 +33,6 @@
 #ifndef PPPCRYPT_H
 #define	PPPCRYPT_H
 
-#ifdef HAVE_CRYPT_H
-#include <crypt.h>
-#endif
-
-#ifndef USE_CRYPT
-#include <des.h>
-#endif
-
 extern bool	DesSetkey __P((u_char *));
 extern bool	DesEncrypt __P((u_char *, u_char *));
 extern bool	DesDecrypt __P((u_char *, u_char *));


### PR DESCRIPTION
The current code supports two sources of DES: libdes (very old) and
libcrypt (still quite common, thanks to POSIX). OpenSSL implements
libdes compatibility, but only as deprecated functions which may not be
availible.

This change adds an option to use the "modern" (13 year old) OpenSSL DES
functions.
