### PR TITLE
PPPD: Fix crash when printing pppol2tp option

### DIFF
--- a/pppd/options.c
+++ b/pppd/options.c
@@ -974,7 +974,7 @@ print_option(opt, mainopt, printer, arg)
 			p = (char *) opt->addr2;
 			if ((opt->flags & OPT_STATIC) == 0)
 				p = *(char **)p;
-			printer("%q", p);
+			printer(arg, "%q", p);
 		} else if (opt->flags & OPT_A2LIST) {
 			struct option_value *ovp;
 

--- a/pppd/plugins/pppol2tp/pppol2tp.c
+++ b/pppd/plugins/pppol2tp/pppol2tp.c
@@ -148,6 +148,10 @@ static int setdevname_pppol2tp(char **argv)
 		fatal("PPPoL2TP kernel driver not installed");
 	}
 
+	pppol2tp_fd_str = strdup(*argv);
+	if (pppol2tp_fd_str == NULL)
+		novm("PPPoL2TP FD");
+
 	/* Setup option defaults. Compression options are disabled! */
 
 	modem = 0;


### PR DESCRIPTION
PPPD crashes (SEGV) when the dump or dryrun options are specified and an option
is internally defined as "o_special" with an option flag of "OPT_A2STRVAL".
As the option value is not saved when the parameter is processed and is later
referenced when the option is printed a crash occurs.
The crash has been observed when using xl2tpd and the l2tp_ppp kernel module.

Additionally the arg argument was missing to the printer call in the print_option
utility when the option flag OPT_A2STRVAL is set.