### PR TITLE
 scripts: Avoid killing wrong pppd

### DIFF
--- a/scripts/poff
+++ b/scripts/poff
@@ -91,7 +91,7 @@ if test "$#" -eq 0 -o "$MODE" = "all" ; then
 fi
 
 # There is an argument, so kill the pppd started on that provider.
-PID=`ps axw | grep "[ /]pppd call $1" | awk '{print $1}'`
+PID=`ps axw | grep "[ /]pppd call $1" | grep -w "$1" | awk '{print $1}'`
 if test -n "$PID" ; then
     $KILL -$SIG $PID || {
         echo "$0: $KILL failed.  None ${DONE}."


### PR DESCRIPTION
poff could kill other pppd processes when there are many pppd running on different serial port. For example, if I run "poff ttyUSB1", pppd running on ttyUSB1, ttyUSB10, ttyUSB13, ttyUSB19 could also be killed.

$ ps axw | grep "pppd call"
 1415 ttyUSB25 SNs+   0:00 /usr/sbin/pppd call ttyUSB25
 3692 pts/4    S+     0:00 grep --colour=auto pppd call
 5077 ttyUSB8  SNs+   0:00 /usr/sbin/pppd call ttyUSB8
 5348 ttyUSB0  SNs+   0:00 /usr/sbin/pppd call ttyUSB0
 9297 ttyUSB16 SNs+   0:00 /usr/sbin/pppd call ttyUSB16
11461 ttyUSB4  SNs+   0:00 /usr/sbin/pppd call ttyUSB4
12625 ?        SNs    0:00 /usr/sbin/pppd call ttyUSB3
13773 ttyUSB22 SNs+   0:00 /usr/sbin/pppd call ttyUSB22
15972 ttyUSB10 SNs+   0:00 /usr/sbin/pppd call ttyUSB10
23029 ttyUSB13 SNs+   0:00 /usr/sbin/pppd call ttyUSB13
24592 ttyUSB19 SNs+   0:00 /usr/sbin/pppd call ttyUSB19