### PR TITLE
pppd: Fix sign-extension when displaying bytes in octal

### DIFF
--- a/pppd/utils.c
+++ b/pppd/utils.c
@@ -625,7 +625,7 @@ print_string(p, len, printer, arg)
 		printer(arg, "\\t");
 		break;
 	    default:
-		printer(arg, "\\%.3o", c);
+		printer(arg, "\\%.3o", (unsigned char) c);
 	    }
 	}
     }


### PR DESCRIPTION
print_string() displays characters as \\%.03o but without first
casting it from "char" to "unsigned char" so it gets sign-extended
to an int. This causes output like \37777777630 instead of \230.

Signed-off-by: Philip A. Prindeville <philipp@redfish-solutions.com>