### PR TITLE
Suppress false error message on PPPoE disconnect

### DIFF
--- a/pppd/plugins/rp-pppoe/plugin.c
+++ b/pppd/plugins/rp-pppoe/plugin.c
@@ -270,7 +270,7 @@ PPPOEDisconnectDevice(void)
     memcpy(sp.sa_addr.pppoe.dev, conn->ifName, IFNAMSIZ);
     memcpy(sp.sa_addr.pppoe.remote, conn->peerEth, ETH_ALEN);
     if (connect(conn->sessionSocket, (struct sockaddr *) &sp,
-		sizeof(struct sockaddr_pppox)) < 0)
+		sizeof(struct sockaddr_pppox)) < 0 && errno != EALREADY)
 	error("Failed to disconnect PPPoE socket: %d %m", errno);
     close(conn->sessionSocket);
     /* don't send PADT?? */


### PR DESCRIPTION
Once the kernel handles PPPoE PADTs correctly[1], a PADT triggered
disconnect will result in EALREADY when pppd tries to clear the session ID.

Simply ignore the error if, and only if, the error is EALREADY

[1] https://patchwork.ozlabs.org/patch/444717/

Signed-off-by: Simon Farnsworth <simon@farnz.org.uk>