### PR TITLE
Send PADT on PPPoE disconnect

### DIFF
--- a/pppd/plugins/rp-pppoe/plugin.c
+++ b/pppd/plugins/rp-pppoe/plugin.c
@@ -273,9 +273,10 @@ PPPOEDisconnectDevice(void)
 		sizeof(struct sockaddr_pppox)) < 0)
 	error("Failed to disconnect PPPoE socket: %d %m", errno);
     close(conn->sessionSocket);
-    /* don't send PADT?? */
-    if (conn->discoverySocket >= 0)
+    if (conn->discoverySocket >= 0) {
+        sendPADT(conn, NULL);
 	close(conn->discoverySocket);
+    }
 }
 
 static void


### PR DESCRIPTION
Once we've terminated the PPP session, there is no chance of a PPP layer
disconnect. Some PPPoE relays don't detect the PPP session going down, and
depend on a long timeout or a PPPoE PADT to terminate the session.

Send a PADT on disconnect to work around these buggy relays.

Signed-off-by: Simon Farnsworth <simon@farnz.org.uk>