### PR TITLE
ppp: fix pppol2tp option printing

### DIFF
--- a/pppd/ipcp.c
+++ b/pppd/ipcp.c
@@ -175,10 +175,10 @@ static option_t ipcp_option_list[] = {
     { "noipdefault", o_bool, &disable_defaultip,
       "Don't use name for default IP adrs", 1 },
 
-    { "ms-dns", 1, (void *)setdnsaddr,
-      "DNS address for the peer's use" },
-    { "ms-wins", 1, (void *)setwinsaddr,
-      "Nameserver for SMB over TCP/IP for peer" },
+    { "ms-dns", o_special, (void *)setdnsaddr,
+      "DNS address for the peer's use", OPT_A2LIST },
+    { "ms-wins", o_special, (void *)setwinsaddr,
+      "Nameserver for SMB over TCP/IP for peer", OPT_A2LIST },
 
     { "ipcp-restart", o_int, &ipcp_fsm[0].timeouttime,
       "Set timeout for IPCP", OPT_PRIO },

--- a/pppd/options.c
+++ b/pppd/options.c
@@ -974,7 +974,7 @@ print_option(opt, mainopt, printer, arg)
 			p = (char *) opt->addr2;
 			if ((opt->flags & OPT_STATIC) == 0)
 				p = *(char **)p;
-			printer("%q", p);
+			printer(arg, "%q", p);
 		} else if (opt->flags & OPT_A2LIST) {
 			struct option_value *ovp;
 

--- a/pppd/plugins/pppol2tp/pppol2tp.c
+++ b/pppd/plugins/pppol2tp/pppol2tp.c
@@ -148,6 +148,10 @@ static int setdevname_pppol2tp(char **argv)
 		fatal("PPPoL2TP kernel driver not installed");
 	}
 
+	pppol2tp_fd_str = strdup(*argv);
+	if (pppol2tp_fd_str == NULL)
+		novm("PPPoL2TP FD");
+
 	/* Setup option defaults. Compression options are disabled! */
 
 	modem = 0;


### PR DESCRIPTION
PPPD crashes (SEGV) when the 'dump' or 'dryrun' options are specified and
an option defined internally as "o_special" with an option flag of
"OPT_A2STRVAL" is used.  The crash occurs because the option value is not
saved when the parameter is processed, but is then referenced when printed.
Additionally, the "arg" parameter is missing from the call to the "printer"
utility.  This was encountered using xl2tpd and the l2tp_ppp kernel module;
the option PPPD crashes on is "pppol2tp 8".

Modify pppd to correctly save the option value, and to call the printer
utility with the correct parameters.

Signed-off-by: Nathan Hintz <nlhintz@hotmail.com>

---

This patch was originally submitted to OpenWRT in:

	https://lists.openwrt.org/pipermail/openwrt-devel/2014-July/026794.html

and was recently accepted in the following changesets:

	https://dev.openwrt.org/changeset/45263
	https://dev.openwrt.org/changeset/45264

Note: This patch resolves issue #32 (https://github.com/paulusmack/ppp/issues/32)