### PR TITLE
Fixed few memory leaks and a 'strncat might overflow'

### DIFF
--- a/pppd/plugins/radius/clientid.c
+++ b/pppd/plugins/radius/clientid.c
@@ -21,6 +21,8 @@ struct map2id_s {
 
 static struct map2id_s *map2id_list = NULL;
 
+#define DEVPATH	"/dev/"
+
 /*
  * Function: rc_read_mapfile
  *
@@ -108,9 +110,9 @@ UINT4 rc_map2id(char *name)
 
 	*ttyname = '\0';
 	if (*name != '/')
-		strcpy(ttyname, "/dev/");
+		strcpy(ttyname, DEVPATH);
 
-	strncat(ttyname, name, sizeof(ttyname));
+	strncat(ttyname, name, sizeof(ttyname) - strlen(DEVPATH));
 
 	for(p = map2id_list; p; p = p->next)
 		if (!strcmp(ttyname, p->name)) return p->id;

--- a/pppd/plugins/radius/config.c
+++ b/pppd/plugins/radius/config.c
@@ -132,7 +132,7 @@ static int set_option_srv(char *filename, int line, OPTION *option, char *p)
 
 static int set_option_auo(char *filename, int line, OPTION *option, char *p)
 {
-	int *iptr;
+	int *iptr = NULL;
 
 	if (p == NULL) {
 		warn("%s: line %d: bogus option value", filename, line);
@@ -153,6 +153,8 @@ static int set_option_auo(char *filename, int line, OPTION *option, char *p)
 			*iptr = AUTH_RADIUS_FST;
 	else {
 		error("%s: auth_order: unknown keyword: %s", filename, p);
+		if (iptr)
+			free(iptr);
 		return (-1);
 	}
 
@@ -165,6 +167,8 @@ static int set_option_auo(char *filename, int line, OPTION *option, char *p)
 			*iptr = (*iptr) | AUTH_RADIUS_SND;
 		else {
 			error("%s: auth_order: unknown or unexpected keyword: %s", filename, p);
+			if (iptr) 
+				free(iptr);
 			return (-1);
 		}
 	}

--- a/pppd/plugins/radius/radrealms.c
+++ b/pppd/plugins/radius/radrealms.c
@@ -44,7 +44,7 @@ lookup_realm(char const *user,
 {
     char *realm;
     FILE *fd;
-    SERVER *accts, *auths, *s;
+    SERVER *accts = NULL, *auths = NULL, *s = NULL;
     char buffer[512], *p;
     int line = 0;
     
@@ -68,6 +68,10 @@ lookup_realm(char const *user,
     
     if ((fd = fopen(radrealms_config, "r")) == NULL) {
 	option_error("cannot open %s", radrealms_config);
+	if (auths) 
+		free(auths);
+	if (accts)
+		free(accts);
 	return;
     } 
     info("Reading %s", radrealms_config);


### PR DESCRIPTION
- [plugins/radius/clientid.c]: in rc_map2id: warning: call to __builtin___strncat_chk might overflow destination buffer
- [plugins/radius/config.c:156]: (error) Memory leak: iptr
- [plugins/radius/config.c:168]: (error) Memory leak: iptr
- [plugins/radius/radrealms.c:71]: (error) Memory leak: accts
- [plugins/radius/radrealms.c:71]: (error) Memory leak: auths
