### PR TITLE
pppd: Add client CHAP authentication timeout

### DIFF
--- a/pppd/pppd.8
+++ b/pppd/pppd.8
@@ -277,6 +277,9 @@ Set the maximum number of CHAP challenge transmissions to \fIn\fR
 Set the CHAP restart interval (retransmission timeout for challenges)
 to \fIn\fR seconds (default 3).
 .TP
+.B chap-timeout \fIn
+Set timeout for CHAP authentication by peer to \fIn\fR seconds (default 60).
+.TP
 .B child\-timeout \fIn
 When exiting, wait for up to \fIn\fR seconds for any child processes
 (such as the command specified with the \fBpty\fR command) to exit


### PR DESCRIPTION
If CHAP authentication is required with the peer but this is never
completed (either because the server never sends the challenge or
because the client doesn't receive the outcome) then the client
will wait forever, relying on the server to terminate the connection.

There are options for server side retries but a client side timeout
option is required to prevent the client from getting stuck if the
server won't terminate the connection. This is defaulted to 60 seconds.
