### PR TITLE
plog: count only relevant lines from syslog

### DIFF
--- a/scripts/plog
+++ b/scripts/plog
@@ -3,5 +3,5 @@
 if [ -s /var/log/ppp.log ]; then
   exec tail "$@" /var/log/ppp.log
 else
-  exec tail "$@" /var/log/syslog | grep ' \(pppd\|chat\)\['
+  exec grep ' \(pppd\|chat\)\[' /var/log/syslog | tail "$@"
 fi


### PR DESCRIPTION
Executing `plog` when `ppp.log` is not present will not show anything is most cases, because it takes the last few lines of `syslog` before grepping. You have to type `plog -n <some large number>` to actually see something.

This pull request makes plog grep first, so it shows the last few _relevant_ lines. See paulusmack/ppp#42.
