### PR TITLE
Added /etc/ppp/ipv6-pre-up script

### DIFF
--- a/pppd/ipv6cp.c
+++ b/pppd/ipv6cp.c
@@ -1146,6 +1146,7 @@ ipv6_demand_conf(u)
 	return 0;
     if (!sif6addr(u, wo->ourid, wo->hisid))
 	return 0;
+    ipv6cp_script(_PATH_IPV6PREUP, 1);
 #if !defined(__linux__) && !(defined(SVR4) && (defined(SNI) || defined(__USLC__)))
     if (!sifup(u))
 	return 0;
@@ -1236,6 +1237,9 @@ ipv6cp_up(f)
 	sifnpmode(f->unit, PPP_IPV6, NPMODE_PASS);
 
     } else {
+	/* run the pre-up script, if any, and wait for it to finish */
+	ipv6cp_script(_PATH_IPV6PREUP, 1);
+
 	/* bring the interface up for IPv6 */
 	if (!sif6up(f->unit)) {
 	    if (debug)

--- a/pppd/pathnames.h
+++ b/pppd/pathnames.h
@@ -38,6 +38,7 @@
 #ifdef INET6
 #define _PATH_IPV6UP     _ROOT_PATH "/etc/ppp/ipv6-up"
 #define _PATH_IPV6DOWN   _ROOT_PATH "/etc/ppp/ipv6-down"
+#define _PATH_IPV6PREUP	 _ROOT_PATH "/etc/ppp/ipv6-pre-up"
 #endif
 
 #ifdef IPX_CHANGE

--- a/pppd/pppd.8
+++ b/pppd/pppd.8
@@ -1592,7 +1592,7 @@ Pppd invokes scripts at various stages in its processing which can be
 used to perform site-specific ancillary processing.  These scripts are
 usually shell scripts, but could be executable code files instead.
 Pppd does not wait for the scripts to finish (except for the ip-pre-up
-script).  The scripts are
+and the ipv6-pre-up script).  The scripts are
 executed as root (with the real and effective user-id set to 0), so
 that they can do things such as update routing tables or run
 privileged daemons.  Be careful that the contents of these scripts do


### PR DESCRIPTION
Vyatta based distros (EdgeOS, VyOS, etc.) are using ip-pre-up.d scripts to rename the ppp device to their format.
However the ip-pre-up script is only invoked by IPCP code, but not IPV6CP. Thus the vyatta scripts has no chance to cleanly do this.
