### PR TITLE
Fix bug in netif_set_mtu for Solaris

### DIFF
--- a/pppd/sys-solaris.c
+++ b/pppd/sys-solaris.c
@@ -1513,7 +1513,7 @@ netif_set_mtu(unit, mtu)
 
     memset(&ifr, 0, sizeof(ifr));
     strlcpy(ifr.ifr_name, ifname, sizeof(ifr.ifr_name));
-    ifr.ifr_metric = link_mtu;
+    ifr.ifr_metric = mtu;
     if (ioctl(ipfd, SIOCSIFMTU, &ifr) < 0) {
 	error("Couldn't set IP MTU (%s): %m", ifr.ifr_name);
     }
@@ -1525,7 +1525,7 @@ netif_set_mtu(unit, mtu)
 
     memset(&lifr, 0, sizeof(lifr));
     strlcpy(lifr.lifr_name, ifname, sizeof(lifr.lifr_name));
-    lifr.lifr_mtu = link_mtu;
+    lifr.lifr_mtu = mtu;
     if (ioctl(fd, SIOCSLIFMTU, &lifr) < 0) {
 	close(fd);
 	error("Couldn't set IPv6 MTU (%s): %m", ifr.ifr_name);


### PR DESCRIPTION
The argument mtu in this function is never used before.
This change makes for example 'pppd ... mtu 1400' works on Solaris.
