### PR TITLE
Add ppp_defs.h include to magic.[ch]

### DIFF
--- a/pppd/magic.c
+++ b/pppd/magic.c
@@ -47,7 +47,7 @@
 #include <unistd.h>
 #include <sys/types.h>
 #include <sys/time.h>
-
+#include "net/ppp_defs.h"
 #include "pppd.h"
 #include "magic.h"
 

--- a/pppd/magic.h
+++ b/pppd/magic.h
@@ -42,6 +42,8 @@
  * $Id: magic.h,v 1.5 2003/06/11 23:56:26 paulus Exp $
  */
 
+#include "net/ppp_defs.h"
+
 void magic_init __P((void));	/* Initialize the magic number generator */
 u_int32_t magic __P((void));	/* Returns the next magic number */
 


### PR DESCRIPTION
magic.[ch] make use of the __P() macro provided by ppp_defs.h, therefore
they should include this header.

This omission did not cause compilation errors with glibc because it
also provides this legacy macro in the non-standard header sys/cdefs.h,
deprecated by musl.

Alternatively, I'd offer to prepare a patch removing the __P() macro from the entire ppp code base if that is acceptable.
