### PR TITLE
Add sys/types.h include to {net,linux}/ppp_defs.h

### DIFF
--- a/include/linux/ppp_defs.h
+++ b/include/linux/ppp_defs.h
@@ -50,6 +50,8 @@
 #ifndef _PPP_DEFS_H_
 #define _PPP_DEFS_H_
 
+#include <sys/types.h>
+
 /*
  * The basic PPP frame.
  */

--- a/include/net/ppp_defs.h
+++ b/include/net/ppp_defs.h
@@ -38,6 +38,8 @@
 #ifndef _PPP_DEFS_H_
 #define _PPP_DEFS_H_
 
+#include <sys/types.h>
+
 /*
  * The basic PPP frame.
  */


### PR DESCRIPTION
struct ppp_idle makes use of the type time_t, which is defined in sys/types.h.
Therefore, ppp_defs.h should include this header.

This issue goes unnoticed with glibc, but causes a compilation error with musl
libc.
