### PR TITLE
Change include from sys/errno.h to errno.h

### DIFF
--- a/pppd/sys-linux.c
+++ b/pppd/sys-linux.c
@@ -73,12 +73,12 @@
 #include <sys/types.h>
 #include <sys/socket.h>
 #include <sys/time.h>
-#include <sys/errno.h>
 #include <sys/file.h>
 #include <sys/stat.h>
 #include <sys/utsname.h>
 #include <sys/sysmacros.h>
 
+#include <errno.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <syslog.h>


### PR DESCRIPTION
According to POSIX, the canonical location for errno.h is on the top level.

This fixes a warning that occurs when compiling against musl libc.
