### PR TITLE
Define error() to print to stderr

### DIFF
--- a/pppd/plugins/rp-pppoe/pppoe-discovery.c
+++ b/pppd/plugins/rp-pppoe/pppoe-discovery.c
@@ -9,6 +9,7 @@
  *
  */
 
+#include <stdarg.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>
@@ -53,6 +54,14 @@ void usage(void);
 void die(int status)
 {
 	exit(status);
+}
+
+void error(char *fmt, ...)
+{
+    va_list pvar;
+    va_start(pvar, fmt);
+    vfprintf(stderr, fmt, pvar);
+    va_end(pvar);
 }
 
 /* Initialize frame types to RFC 2516 values.  Some broken peers apparently


### PR DESCRIPTION
The pppoe-discovery program calls error() from the CHECK_ROOM macro
defined in pppoe.h. Since this standalone program is not linked with the
rest of pppd, the only way this can build is by linking to glibc's
proprietary error(3) function instead of the function of the same name
(but with different arguments) defined in pppd/utils.c.

So when linked with glibc, this probably crashes when the assertion
fails. With musl libc, the binary cannot be built in the first place
because it does not provide the doppelganger.
