### PR TITLE
pppd: Remove unused declaration of ttyname.

### DIFF
--- a/pppd/main.c
+++ b/pppd/main.c
@@ -257,7 +257,6 @@ static void cleanup_db __P((void));
 static void handle_events __P((void));
 void print_link_stats __P((void));
 
-extern	char	*ttyname __P((int));
 extern	char	*getlogin __P((void));
 int main __P((int, char *[]));
 


### PR DESCRIPTION
Yes, this does actually make a difference. :)

There's a new FORTIFY implementation floating about that doesn't like it when some standard library functions are redeclared without a special, compiler-specific attribute. So, when trying to compile ppp with said FORTIFY impl enabled, my compiler complained about this redeclaration.

With it removed, everything works fine.
