### PR TITLE
ppp: fix building with linux-4.8

### DIFF
--- a/pppd/plugins/rp-pppoe/pppoe.h
+++ b/pppd/plugins/rp-pppoe/pppoe.h
@@ -84,7 +84,7 @@ typedef unsigned long UINT32_t;
 #include <linux/if_ether.h>
 #endif
 
-#include <netinet/in.h>
+#include <linux/in.h>
 
 #ifdef HAVE_NETINET_IF_ETHER_H
 #include <sys/types.h>


### PR DESCRIPTION
Fix a build error when using the linux-4.8 headers that results in:

In file included from pppoe.h:87:0,
                 from plugin.c:29:
../usr/include/netinet/in.h:211:8: note: originally defined here
 struct in6_addr
        ^~~~~~~~
In file included from ../usr/include/linux/if_pppol2tp.h:20:0,
                 from ../usr/include/linux/if_pppox.h:26,
                 from plugin.c:52:
../usr/include/linux/in6.h:49:8: error: redefinition of 'struct sockaddr_in6'
 struct sockaddr_in6 {
        ^~~~~~~~~~~~

Signed-off-by: Jackie Huang jackie.huang@windriver.com
