### PR TITLE
pppoe: include netinet/in.h before linux/in.h

### DIFF
--- a/pppd/plugins/rp-pppoe/pppoe.h
+++ b/pppd/plugins/rp-pppoe/pppoe.h
@@ -47,6 +47,10 @@
 #include <sys/socket.h>
 #endif
 
+/* This has to be included before Linux 4.8's linux/in.h
+ * gets dragged in. */
+#include <netinet/in.h>
+
 /* Ugly header files on some Linux boxes... */
 #if defined(HAVE_LINUX_IF_H)
 #include <linux/if.h>
@@ -84,8 +88,6 @@ typedef unsigned long UINT32_t;
 #include <linux/if_ether.h>
 #endif
 
-#include <netinet/in.h>
-
 #ifdef HAVE_NETINET_IF_ETHER_H
 #include <sys/types.h>
 
@@ -96,7 +98,6 @@ typedef unsigned long UINT32_t;
 #include <netinet/if_ether.h>
 #endif
 #endif
-
 
 
 /* Ethernet frame types according to RFC 2516 */


### PR DESCRIPTION
This fixes builds with newer kernels. Basically, <netinet/in.h> needs to be
included before <linux/in.h> otherwise the earlier, unaware of the latter,
tries to redefine symbols and structures. Also, <linux/if_pppox.h> doesn't work
alone anymore, since it pulls the headers in the wrong order, so we better
include <netinet/in.h> early.