### PR TITLE
Add defaultroute6 options

### DIFF
--- a/pppd/ipv6cp.c
+++ b/pppd/ipv6cp.c
@@ -178,6 +178,7 @@ ipv6cp_options ipv6cp_hisoptions[NUM_PPP];	/* Options that we ack'd */
 int no_ifaceid_neg = 0;
 
 /* local vars */
+static int default_route_set[NUM_PPP];		/* Have set up a default route */
 static int ipv6cp_is_up;
 
 /* Hook for a plugin to know when IPv6 protocol has come up */
@@ -245,6 +246,15 @@ static option_t ipv6cp_option_list[] = {
 
     { "ipv6cp-accept-local", o_bool, &ipv6cp_allowoptions[0].accept_local,
       "Accept peer's interface identifier for us", 1 },
+
+    { "defaultroute6", o_bool, &ipv6cp_wantoptions[0].default_route,
+      "Add default IPv6 route", OPT_ENABLE|1, &ipv6cp_allowoptions[0].default_route },
+    { "nodefaultroute6", o_bool, &ipv6cp_allowoptions[0].default_route,
+      "disable defaultroute6 option", OPT_A2CLR,
+      &ipv6cp_wantoptions[0].default_route },
+    { "-defaultroute6", o_bool, &ipv6cp_allowoptions[0].default_route,
+      "disable defaultroute6 option", OPT_ALIAS | OPT_A2CLR,
+      &ipv6cp_wantoptions[0].default_route },
 
     { "ipv6cp-use-ipaddr", o_bool, &ipv6cp_allowoptions[0].use_ip,
       "Use (default) IPv4 address as interface identifier", 1 },
@@ -444,6 +454,10 @@ ipv6cp_init(unit)
     wo->vj_protocol = IPV6CP_COMP;
 #endif
 
+    /*
+     * XXX This controls whether the user may use the defaultroute option.
+     */
+    ao->default_route = 1;
 }
 
 
@@ -1152,6 +1166,9 @@ ipv6_demand_conf(u)
 #endif
     if (!sifnpmode(u, PPP_IPV6, NPMODE_QUEUE))
 	return 0;
+    if (wo->default_route)
+	if (sif6defaultroute(u, wo->ourid, wo->hisid))
+	    default_route_set[u] = 1;
 
     notice("ipv6_demand_conf");
     notice("local  LL address %s", llv6_ntoa(wo->ourid));
@@ -1231,6 +1248,10 @@ ipv6cp_up(f)
 		return;
 	    }
 
+	    /* assign a default route through the interface if required */
+	    if (ipv6cp_wantoptions[f->unit].default_route)
+		if (sif6defaultroute(f->unit, go->ourid, ho->hisid))
+		    default_route_set[f->unit] = 1;
 	}
 	demand_rexmit(PPP_IPV6);
 	sifnpmode(f->unit, PPP_IPV6, NPMODE_PASS);
@@ -1251,6 +1272,11 @@ ipv6cp_up(f)
 	    return;
 	}
 	sifnpmode(f->unit, PPP_IPV6, NPMODE_PASS);
+
+	/* assign a default route through the interface if required */
+	if (ipv6cp_wantoptions[f->unit].default_route)
+	    if (sif6defaultroute(f->unit, go->ourid, ho->hisid))
+		default_route_set[f->unit] = 1;
 
 	notice("local  LL address %s", llv6_ntoa(go->ourid));
 	notice("remote LL address %s", llv6_ntoa(ho->hisid));

--- a/pppd/ipv6cp.h
+++ b/pppd/ipv6cp.h
@@ -150,6 +150,7 @@
 typedef struct ipv6cp_options {
     int neg_ifaceid;		/* Negotiate interface identifier? */
     int req_ifaceid;		/* Ask peer to send interface identifier? */
+    int default_route;		/* Assign default route through interface? */
     int accept_local;		/* accept peer's value for iface id? */
     int opt_local;		/* ourtoken set by option */
     int opt_remote;		/* histoken set by option */

--- a/pppd/pppd.8
+++ b/pppd/pppd.8
@@ -127,6 +127,12 @@ is no other default route with the same metric.  With the default
 value of -1, the route is only added if there is no default route at
 all.
 .TP
+.B defaultroute6
+Add a default IPv6 route to the system routing tables, using the peer as
+the gateway, when IPv6CP negotiation is successfully completed.
+This entry is removed when the PPP connection is broken.  This option
+is privileged if the \fInodefaultroute6\fR option has been specified.
+.TP
 .B disconnect \fIscript
 Execute the command specified by \fIscript\fR, by passing it to a
 shell, after
@@ -741,6 +747,11 @@ disable both forms of hardware flow control.
 .B nodefaultroute
 Disable the \fIdefaultroute\fR option.  The system administrator who
 wishes to prevent users from creating default routes with pppd
+can do so by placing this option in the /etc/ppp/options file.
+.TP
+.B nodefaultroute6
+Disable the \fIdefaultroute6\fR option.  The system administrator who
+wishes to prevent users from adding a default route with pppd
 can do so by placing this option in the /etc/ppp/options file.
 .TP
 .B nodeflate

--- a/pppd/pppd.h
+++ b/pppd/pppd.h
@@ -669,6 +669,12 @@ int  sifdefaultroute __P((int, u_int32_t, u_int32_t));
 				/* Create default route through i/f */
 int  cifdefaultroute __P((int, u_int32_t, u_int32_t));
 				/* Delete default route through i/f */
+#ifdef INET6
+int  sif6defaultroute __P((int, eui64_t, eui64_t));
+				/* Create default IPv6 route through i/f */
+int  cif6defaultroute __P((int, eui64_t, eui64_t));
+				/* Delete default IPv6 route through i/f */
+#endif
 int  sifproxyarp __P((int, u_int32_t));
 				/* Add proxy ARP entry for peer */
 int  cifproxyarp __P((int, u_int32_t));


### PR DESCRIPTION
Which behaves like IPv4's defaultroute.

Signed-off-by: Samuel Thibault <samuel.thibault@ens-lyon.org>