### PR TITLE
Use systemd's sd_notify with option up_sdnotify

### DIFF
--- a/pppd/Makefile.linux
+++ b/pppd/Makefile.linux
@@ -60,6 +60,11 @@ HAVE_MULTILINK=y
 # Linux distributions: Please leave TDB ENABLED in your builds.
 USE_TDB=y
 
+# Uncomment the next line to enable Type=notify services in systemd
+# If enabled, and the user sets the up_sdnotify option, then
+# pppd will not detach and will notify systemd when up.
+#SYSTEMD=y
+
 HAS_SHADOW=y
 #USE_PAM=y
 HAVE_INET6=y
@@ -168,6 +173,11 @@ endif
 ifdef LOCKLIB
 LIBS     += -llock
 CFLAGS   += -DLOCKLIB=1
+endif
+
+ifdef SYSTEMD
+LIBS += -lsystemd
+CFLAGS   += -DSYSTEMD=1
 endif
 
 ifdef PLUGIN

--- a/pppd/auth.c
+++ b/pppd/auth.c
@@ -100,6 +100,10 @@
 #endif
 #include <time.h>
 
+#ifdef SYSTEMD
+#include <systemd/sd-daemon.h>
+#endif
+
 #include "pppd.h"
 #include "fsm.h"
 #include "lcp.h"
@@ -1099,8 +1103,15 @@ np_up(unit, proto)
 	/*
 	 * Detach now, if the updetach option was given.
 	 */
-	if (updetach && !nodetach)
+	if (updetach && !nodetach) {
+	    dbglog("updetach is set. Now detaching.");
 	    detach();
+#ifdef SYSTEMD
+	} else if (nodetach && up_sdnotify) {
+	    dbglog("up_sdnotify is set. Now notifying systemd: READY=1");
+	    sd_notify(0, "READY=1");
+#endif
+	}
     }
     ++num_np_up;
 }

--- a/pppd/options.c
+++ b/pppd/options.c
@@ -97,6 +97,9 @@ char	devnam[MAXPATHLEN];	/* Device name */
 bool	nodetach = 0;		/* Don't detach from controlling tty */
 bool	updetach = 0;		/* Detach once link is up */
 bool	master_detach;		/* Detach when we're (only) multilink master */
+#ifdef SYSTEMD
+bool	up_sdnotify = 0;	/* Notify systemd once link is up */
+#endif
 int	maxconnect = 0;		/* Maximum connect time */
 char	user[MAXNAMELEN];	/* Username for PAP */
 char	passwd[MAXSECRETLEN];	/* Password for PAP */
@@ -209,6 +212,11 @@ option_t general_options[] = {
       "Don't detach from controlling tty", OPT_PRIO | 1 },
     { "-detach", o_bool, &nodetach,
       "Don't detach from controlling tty", OPT_ALIAS | OPT_PRIOSUB | 1 },
+#ifdef SYSTEMD
+    { "up_sdnotify", o_bool, &up_sdnotify,
+      "Notify systemd once link is up (implies nodetach)",
+      OPT_PRIOSUB | OPT_A2COPY | 1, &nodetach },
+#endif
     { "updetach", o_bool, &updetach,
       "Detach from controlling tty once link is up",
       OPT_PRIOSUB | OPT_A2CLR | 1, &nodetach },

--- a/pppd/pppd.8
+++ b/pppd/pppd.8
@@ -1100,6 +1100,15 @@ it has successfully established the ppp connection (to the point where
 the first network control protocol, usually the IP control protocol,
 has come up).
 .TP
+.B up_sdnotify
+Use this option to run pppd in systemd service units of Type=notify
+(\fBup_sdnotify\fR implies \fBnodetach\fR).
+When \fBup_sdnotify\fR is enabled, pppd will notify systemd once
+it has successfully established the ppp connection (to the point where
+the first network control protocl, usually the IP control protocol,
+has come up). This option is only availble when pppd is compiled with
+systemd support.
+.TP
 .B usehostname
 Enforce the use of the hostname (with domain name appended, if given)
 as the name of the local system for authentication purposes (overrides

--- a/pppd/pppd.h
+++ b/pppd/pppd.h
@@ -295,6 +295,9 @@ extern int	inspeed;	/* Input/Output speed requested */
 extern u_int32_t netmask;	/* IP netmask to set on interface */
 extern bool	lockflag;	/* Create lock file to lock the serial dev */
 extern bool	nodetach;	/* Don't detach from controlling tty */
+#ifdef SYSTEMD
+extern bool	up_sdnotify;	/* Notify systemd once link is up (implies nodetach) */
+#endif
 extern bool	updetach;	/* Detach from controlling tty when link up */
 extern bool	master_detach;	/* Detach when multilink master without link */
 extern char	*initializer;	/* Script to initialize physical link */


### PR DESCRIPTION
This adds an up_sdnotify option so that systemd services of
Type=notify can have pppd send the READY=1 signal to systemd
once a network protocol (typically IP) is up.

To use up_sdnotify, pppd must be compiled with SYSTEMD=y.

Resolves #70