### PR TITLE
Allow pppd to start as non-root.

### DIFF
--- a/pppd/main.c
+++ b/pppd/main.c
@@ -371,6 +371,7 @@ main(argc, argv)
     if (debug)
 	setlogmask(LOG_UPTO(LOG_DEBUG));
 
+#ifndef ALLOW_START_AS_NON_ROOT
     /*
      * Check that we are running as root.
      */
@@ -379,6 +380,7 @@ main(argc, argv)
 		     argv[0]);
 	exit(EXIT_NOT_ROOT);
     }
+#endif
 
     if (!ppp_available()) {
 	option_error("%s", no_ppp_msg);

--- a/pppd/options.c
+++ b/pppd/options.c
@@ -694,11 +694,13 @@ process_option(opt, cmd, argv)
 		     opt->name, optopt);
 	return 0;
     }
+#ifndef ALLOW_START_AS_NON_ROOT
     if ((opt->flags & OPT_PRIV) && !privileged_option) {
 	option_error("using the %s%s requires root privilege",
 		     opt->name, optopt);
 	return 0;
     }
+#endif
     if ((opt->flags & OPT_ENABLE) && *(bool *)(opt->addr2) == 0) {
 	option_error("%s%s is disabled", opt->name, optopt);
 	return 0;


### PR DESCRIPTION
This patch adds #ifndef macros in 2 spots in order to allow pppd to be
spawned as a non-root user with only runtime capabilities (e.g.
CAP_NET_{RAW/ADMIN}) instead of giving pppd full root privileges. This
is helpful if pppd is itself spawned by a non-root user and the use of
file permissions (e.g. setuid-root) on the pppd binary is not a
desirable solution.