### PR TITLE
Support for interface renaming by pre-up scripts

### DIFF
--- a/pppd/ipcp.c
+++ b/pppd/ipcp.c
@@ -55,6 +55,7 @@
 #include <sys/socket.h>
 #include <netinet/in.h>
 #include <arpa/inet.h>
+#include <net/if.h>
 
 #include "pppd.h"
 #include "fsm.h"
@@ -1788,6 +1789,7 @@ ipcp_up(f)
     ipcp_options *ho = &ipcp_hisoptions[f->unit];
     ipcp_options *go = &ipcp_gotoptions[f->unit];
     ipcp_options *wo = &ipcp_wantoptions[f->unit];
+    int ifindex;
 
     IPCPDEBUG(("ipcp: up"));
 
@@ -1901,8 +1903,17 @@ ipcp_up(f)
 	}
 #endif
 
+	ifindex = if_nametoindex(ifname);
+
 	/* run the pre-up script, if any, and wait for it to finish */
 	ipcp_script(_PATH_IPPREUP, 1);
+
+	/* check if preup script renamed the interface */
+	if (!if_indextoname(ifindex, ifname)) {
+            error("Interface index %d failed to get renamed by a pre-up script", ifindex);
+	    ipcp_close(f->unit, "Interface configuration failed");
+	    return;
+	}
 
 	/* bring the interface up for IP */
 	if (!sifup(f->unit)) {


### PR DESCRIPTION
When running, for example, both an L2TP/IPsec and a PPTP server on the same machine, it's nice to have them use different names for client interfaces , for example l2tpX and pptpX. It could be done with pre-ip-up scripts, but pppd assumes that interface name is not changed by them.

This is a patch made by Stephen Hemminger back in Vyatta times, but to my knowledge he never sent it to the maintainers. We are still using it in VyOS and it works well for us, but it would be nice if other people could benefit from it too (and we didn't have to maintain a custom version of pppd).

It looks POSIX-compliant to me, but I do admit I've never tested it on systems other than Linux. If there are any compatibility problems with it or other issues, I'm ready to work on them.