### PR TITLE
pppd: fix `ifname` option in case of multilink

### DIFF
--- a/pppd/main.c
+++ b/pppd/main.c
@@ -735,6 +735,9 @@ set_ifunit(iskey)
 	slprintf(ifname, sizeof(ifname), "%s%d", PPP_DRV_NAME, ifunit);
     info("Using interface %s", ifname);
     script_setenv("IFNAME", ifname, iskey);
+    char ifkey[32];
+    slprintf(ifkey, sizeof(ifkey), "%d", ifunit);
+    script_setenv("UNIT", ifkey, iskey);
     if (iskey) {
 	create_pidfile(getpid());	/* write pid to file */
 	create_linkpidfile(getpid());

--- a/pppd/multilink.c
+++ b/pppd/multilink.c
@@ -204,7 +204,7 @@ mp_join_bundle()
 			/* make sure the string is null-terminated */
 			rec.dptr[rec.dsize-1] = 0;
 			/* parse the interface number */
-			parse_num(rec.dptr, "IFNAME=ppp", &unit);
+			parse_num(rec.dptr, "UNIT=", &unit);
 			/* check the pid value */
 			if (!parse_num(rec.dptr, "PPPD_PID=", &pppd_pid)
 			    || !process_exists(pppd_pid)
@@ -420,7 +420,7 @@ owns_unit(key, unit)
 	TDB_DATA kd, vd;
 	int ret = 0;
 
-	slprintf(ifkey, sizeof(ifkey), "IFNAME=ppp%d", unit);
+	slprintf(ifkey, sizeof(ifkey), "UNIT=%d", unit);
 	kd.dptr = ifkey;
 	kd.dsize = strlen(ifkey);
 	vd = tdb_fetch(pppdb, kd);
@@ -589,4 +589,3 @@ str_to_epdisc(ep, str)
 	ep->length = l;
 	return 1;
 }
-


### PR DESCRIPTION
Make pppd use the unit and not the interface name to get the bundle.

pppd was looking for the default interface name (`pppX`) in the
database to retreive the bundle id on which a new link should
attach, and fails if the `ifname` option is used.