### PR TITLE
pppd: Check tbd pointer before closing

### DIFF
--- a/pppd/main.c
+++ b/pppd/main.c
@@ -1566,7 +1566,8 @@ safe_fork(int infd, int outfd, int errfd)
 	/* Executing in the child */
 	sys_close();
 #ifdef USE_TDB
-	tdb_close(pppdb);
+	if (pppdb != NULL)
+		tdb_close(pppdb);
 #endif
 
 	/* make sure infd, outfd and errfd won't get tromped on below */


### PR DESCRIPTION
Check that pointer to the tdb is not NULL before calling tdb_close().
It is possible that the file could not be opened/created due to
permission issues. This change prevents the crash that happens in that
case.