### PR TITLE
pppd: free of memory not on the heap in multilink

### DIFF
--- a/pppd/multilink.c
+++ b/pppd/multilink.c
@@ -445,12 +445,16 @@ get_default_epdisc(ep)
 	if (p != 0 && get_if_hwaddr(ep->value, p) >= 0) {
 		ep->class = EPD_MAC;
 		ep->length = 6;
+		#ifndef __linux__
 		free(p);
+		#endif
 		return 1;
 	}
 
+	#ifndef __linux__
 	if (p)
 		free(p);
+	#endif
 
 	/* see if our hostname corresponds to a reasonable IP address */
 	hp = gethostbyname(hostname);


### PR DESCRIPTION
On Linux, pppd may attempt to free memory that is statically allocated. This bug can be provoked by executing, for instance, "pppd login mp".

Freeing memory that has not been allocated on the heap can in the worst case lead to arbitrary code execution (https://cwe.mitre.org/data/definitions/590.html). However, because (i) the memory region that is attempted to be freed cannot be controlled by an adversary and (ii) the bug can only be triggered locally, I find this bug is not security sensitive.

To fix this bug, I propose that the free() operation is only executed on Solaris (not on Linux), where "p" is actually allocated on the heap.
