### PR TITLE
fix: send PAP NAK with success message

### DIFF
--- a/pppd/session.c
+++ b/pppd/session.c
@@ -186,8 +186,6 @@ session_start(flags, user, passwd, ttyName, msg)
 #endif /* #ifdef HAS_SHADOW */
 #endif /* #ifdef USE_PAM */
 
-    SET_MSG(msg, SUCCESS_MSG);
-
     /* If no verification is requested, then simply return an OK */
     if (!(SESS_ALL & flags)) {
         return SESSION_OK;


### PR DESCRIPTION
function "session_start" may return SESSION_FAILED with successfull message.
The debug message like this:
sent [PAP AuthNak id=0xed "Session started successfully"]