### PR TITLE
pppd: Print version information to stdout instead of stderr

### DIFF
--- a/pppd/options.c
+++ b/pppd/options.c
@@ -1088,7 +1088,7 @@ showversion(argv)
     char **argv;
 {
     if (phase == PHASE_INITIALIZE) {
-	fprintf(stderr, "pppd version %s\n", VERSION);
+	fprintf(stdout, "pppd version %s\n", VERSION);
 	exit(0);
     }
     return 0;


### PR DESCRIPTION
This makes it easier for scripts to parse the output if necessary

Signed-off-by: Lars Wendler <polynomial-c@gentoo.org>