### PR TITLE
Adding EAP-MSCHAPv2 support

### DIFF
--- a/pppd/Makefile.linux
+++ b/pppd/Makefile.linux
@@ -33,7 +33,7 @@ endif
 # CC = gcc
 #
 COPTS = -O2 -pipe -Wall -g
-LIBS =
+LIBS = -lrt
 
 # Uncomment the next line to include support for Microsoft's
 # MS-CHAP authentication protocol.  Also, edit plugins/radius/Makefile.linux.

--- a/pppd/Makefile.linux
+++ b/pppd/Makefile.linux
@@ -99,6 +99,7 @@ CFLAGS   += -DMSLANMAN=1
 endif
 ifdef MPPE
 CFLAGS   += -DMPPE=1
+HEADERS  += mppe.h
 endif
 endif
 

--- a/pppd/eap.c
+++ b/pppd/eap.c
@@ -64,6 +64,9 @@
 #include "pathnames.h"
 #include "md5.h"
 #include "eap.h"
+#ifdef CHAPMS
+#include "chap_ms.h"
+#endif
 
 #ifdef USE_SRP
 #include <t_pwd.h>
@@ -1302,6 +1305,47 @@ int len, id;
 }
 #endif /* USE_SRP */
 
+#if CHAPMS
+/*
+ * Format and send an CHAPV2-Challenge EAP Response message.
+ */
+static void
+eap_chapv2_response(esp, id, chapid, response, user, user_len)
+eap_state *esp;
+u_char id;
+u_char chapid;
+u_char *response;
+char *user;
+int user_len;
+{
+	u_char *outp;
+	int msglen;
+
+	outp = outpacket_buf;
+    
+	MAKEHEADER(outp, PPP_EAP);
+
+	PUTCHAR(EAP_RESPONSE, outp);
+	PUTCHAR(id, outp);
+	esp->es_client.ea_id = id;
+	msglen = EAP_HEADERLEN + 6 * sizeof (u_char) + MS_CHAP2_RESPONSE_LEN + user_len;
+	PUTSHORT(msglen, outp);
+	PUTCHAR(EAPT_MSCHAPV2, outp);
+	PUTCHAR(CHAP_RESPONSE, outp);
+	PUTCHAR(chapid, outp);
+	PUTCHAR(0, outp);
+	/* len */
+	PUTCHAR(5 + user_len +MS_CHAP2_RESPONSE_LEN, outp);
+	/* len response */
+	PUTCHAR(MS_CHAP2_RESPONSE_LEN, outp)
+	BCOPY(response, outp, MS_CHAP2_RESPONSE_LEN);
+	INCPTR(MS_CHAP2_RESPONSE_LEN, outp);
+	BCOPY(user, outp, user_len);
+
+	output(esp->es_unit, outpacket_buf, PPP_HDRLEN + msglen);
+}
+#endif
+
 /*
  * eap_request - Receive EAP Request message (client mode).
  */
@@ -1460,6 +1504,97 @@ int len;
 		eap_chap_response(esp, id, hash, esp->es_client.ea_name,
 		    esp->es_client.ea_namelen);
 		break;
+
+#ifdef CHAPMS
+	case EAPT_MSCHAPV2:
+		if (len < 1) {
+			error("EAP: received short MSCHAPv2");
+			/* Bogus request; wait for something real. */
+			return;
+		}
+		unsigned char chopcode;
+		GETCHAR(chopcode, inp);
+		len--;
+		dbglog("EAP: CHAP opcode %d", chopcode);
+
+		if (chopcode==CHAP_CHALLENGE) {
+
+			unsigned char chapid; /* Chapv2-ID */
+			GETCHAR(chapid, inp);
+			short mssize;
+			GETSHORT(mssize, inp);
+			unsigned char vsize; 
+			GETCHAR(vsize, inp);
+			len-=4;
+
+			dbglog("EAP: chapid %d mssize %d vsize %d inplen %d, challen %d", chapid, mssize, vsize, len, MS_CHAP2_PEER_CHAL_LEN);
+
+			unsigned char *rchallenge = calloc(1, MS_CHAP2_PEER_CHAL_LEN);
+			BCOPY(inp, rchallenge, MS_CHAP2_PEER_CHAL_LEN);
+			INCPTR(MS_CHAP2_PEER_CHAL_LEN,inp);
+
+			/*
+			 * Get the secret for authenticating ourselves with
+			 * the specified host.
+			 */
+			if (!get_secret(esp->es_unit, esp->es_client.ea_name,
+			    rhostname, secret, &secret_len, 0)) {
+				dbglog("EAP: no CHAP secret for auth to %q", rhostname);
+				eap_send_nak(esp, id, EAPT_SRP);
+				break;
+			}
+
+			char *user = calloc(1, esp->es_client.ea_namelen + 1);
+			memcpy(user, esp->es_client.ea_name, esp->es_client.ea_namelen);
+			*(user + esp->es_client.ea_namelen) = '\0';
+			dbglog("EAP: user %s, user_len %d", user, esp->es_client.ea_namelen);
+
+			/* mschapv2 response */
+			unsigned char response[49];
+			unsigned char authResponse[41];
+			ChapMS2(rchallenge, NULL, user, secret, secret_len, response,
+					authResponse, MS_CHAP2_AUTHENTICATEE);
+
+			eap_chapv2_response(esp, id, chapid, response, esp->es_client.ea_name, esp->es_client.ea_namelen);
+
+			free(user);
+			free(rchallenge);
+
+		} else if (chopcode==CHAP_SUCCESS) {
+
+			unsigned char chapid; /* Chapv2-ID */
+			GETCHAR(chapid, inp);
+			short mssize;
+			GETSHORT(mssize, inp);
+			len-=3;
+			dbglog("EAP: chapid %d mssize %d inplen %d", chapid, mssize, len );
+			dbglog("Chap authentication succeeded: %.*v", len, inp);
+			u_char response[1];
+			response[0]=CHAP_SUCCESS;
+			eap_send_response(esp, id, EAPT_MSCHAPV2, response, 1);
+
+		} else if (chopcode==CHAP_FAILURE) {
+
+			unsigned char chapid; /* Chapv2-ID */
+			GETCHAR(chapid, inp);
+			short mssize;
+			GETSHORT(mssize, inp);
+			len-=3;
+			dbglog("EAP: chapid %d mssize %d inplen %d", chapid, mssize, len );
+			dbglog("Chap authentication failed: %.*v", len, inp);
+			u_char response[1];
+			response[0]=CHAP_FAILURE;
+			eap_send_response(esp, id, EAPT_MSCHAPV2, response, 1);
+			goto client_failure; /* force termination */
+
+		} else {
+
+			dbglog("EAP: Unknown CHAP opcode %d", chopcode);
+			eap_send_nak(esp, id, EAPT_SRP);
+		}
+
+		break;
+#endif /* CHAPMS */
 
 #ifdef USE_SRP
 	case EAPT_SRP:
@@ -1706,16 +1841,16 @@ int len;
 	}
 	return;
 
-#ifdef USE_SRP
 client_failure:
 	esp->es_client.ea_state = eapBadAuth;
 	if (esp->es_client.ea_timeout > 0) {
 		UNTIMEOUT(eap_client_timeout, (void *)esp);
 	}
 	esp->es_client.ea_session = NULL;
+#ifdef USE_SRP
 	t_clientclose(tc);
-	auth_withpeer_fail(esp->es_unit, PPP_EAP);
 #endif /* USE_SRP */
+	auth_withpeer_fail(esp->es_unit, PPP_EAP);
 }
 
 /*
@@ -2154,7 +2289,9 @@ static char *eap_typenames[] = {
 	"OTP", "Generic-Token", NULL, NULL,
 	"RSA", "DSS", "KEA", "KEA-Validate",
 	"TLS", "Defender", "Windows 2000", "Arcot",
-	"Cisco", "Nokia", "SRP"
+	"Cisco", "Nokia", "SRP", NULL,
+	"TTLS", "RAS", "AKA", "3COM", "PEAP",
+	"MSCHAPv2"
 };
 
 static int

--- a/pppd/eap.h
+++ b/pppd/eap.h
@@ -59,6 +59,18 @@ extern "C" {
 #define	EAPT_NOKIACARD		18	/* Nokia IP smart card */
 #define	EAPT_SRP		19	/* Secure Remote Password */
 /* 20 is deprecated */
+#define	EAPT_TTLS		21	/* EAP Tunneled TLS Authentication Protocol RFC5281 */
+#define	EAPT_RAS		22	/* Remote Access Service */
+#define	EAPT_AKA		23	/* EAP method for 3rd Generation Authentication and Key Agreement RFC4187 */
+#define	EAPT_3COM		24	/* EAP-3Com Wireless */
+#define	EAPT_PEAP		25	/* Protected EAP */
+#define	EAPT_MSCHAPV2		26	/* EAP-MSCHAPv2 RFC-draft-kamath-pppext-eap-mschapv2-02 */
+
+/* OpCodes for MSCHAPv2 */
+#define CHAP_CHALLENGE	1
+#define CHAP_RESPONSE	2
+#define CHAP_SUCCESS	3
+#define CHAP_FAILURE	4
 
 /* EAP SRP-SHA1 Subtypes */
 #define	EAPSRP_CHALLENGE	1	/* Request 1 - Challenge */

--- a/pppd/lcp.c
+++ b/pppd/lcp.c
@@ -72,6 +72,7 @@ static void lcp_delayed_up __P((void *));
  */
 int	lcp_echo_interval = 0; 	/* Interval between LCP echo-requests */
 int	lcp_echo_fails = 0;	/* Tolerance to unanswered echo-requests */
+bool	lcp_echo_adaptive = 0;	/* request echo only if the link was idle */
 bool	lax_recv = 0;		/* accept control chars in asyncmap */
 bool	noendpoint = 0;		/* don't send/accept endpoint discriminator */
 
@@ -150,6 +151,8 @@ static option_t lcp_option_list[] = {
       OPT_PRIO },
     { "lcp-echo-interval", o_int, &lcp_echo_interval,
       "Set time in seconds between LCP echo requests", OPT_PRIO },
+    { "lcp-echo-adaptive", o_bool, &lcp_echo_adaptive,
+      "Suppress LCP echo requests if traffic was received", 1 },
     { "lcp-restart", o_int, &lcp_fsm[0].timeouttime,
       "Set time in seconds between LCP retransmissions", OPT_PRIO },
     { "lcp-max-terminate", o_int, &lcp_fsm[0].maxtermtransmits,
@@ -2327,6 +2330,22 @@ LcpSendEchoRequest (f)
         if (lcp_echos_pending >= lcp_echo_fails) {
             LcpLinkFailure(f);
 	    lcp_echos_pending = 0;
+	}
+    }
+
+    /*
+     * If adaptive echos have been enabled, only send the echo request if
+     * no traffic was received since the last one.
+     */
+    if (lcp_echo_adaptive) {
+	static unsigned int last_pkts_in = 0;
+
+	update_link_stats(f->unit);
+	link_stats_valid = 0;
+
+	if (link_stats.pkts_in != last_pkts_in) {
+	    last_pkts_in = link_stats.pkts_in;
+	    return;
 	}
     }
 

--- a/pppd/main.c
+++ b/pppd/main.c
@@ -520,7 +520,7 @@ main(argc, argv)
 	    info("Starting link");
 	}
 
-	gettimeofday(&start_time, NULL);
+	get_time(&start_time);
 	script_unsetenv("CONNECT_TIME");
 	script_unsetenv("BYTES_SENT");
 	script_unsetenv("BYTES_RCVD");
@@ -1228,7 +1228,7 @@ reset_link_stats(u)
 {
     if (!get_ppp_stats(u, &old_link_stats))
 	return;
-    gettimeofday(&start_time, NULL);
+    get_time(&start_time);
 }
 
 /*
@@ -1242,7 +1242,7 @@ update_link_stats(u)
     char numbuf[32];
 
     if (!get_ppp_stats(u, &link_stats)
-	|| gettimeofday(&now, NULL) < 0)
+	|| get_time(&now) < 0)
 	return;
     link_connect_time = now.tv_sec - start_time.tv_sec;
     link_stats_valid = 1;
@@ -1289,7 +1289,7 @@ timeout(func, arg, secs, usecs)
 	fatal("Out of memory in timeout()!");
     newp->c_arg = arg;
     newp->c_func = func;
-    gettimeofday(&timenow, NULL);
+    get_time(&timenow);
     newp->c_time.tv_sec = timenow.tv_sec + secs;
     newp->c_time.tv_usec = timenow.tv_usec + usecs;
     if (newp->c_time.tv_usec >= 1000000) {
@@ -1343,7 +1343,7 @@ calltimeout()
     while (callout != NULL) {
 	p = callout;
 
-	if (gettimeofday(&timenow, NULL) < 0)
+	if (get_time(&timenow) < 0)
 	    fatal("Failed to get time of day: %m");
 	if (!(p->c_time.tv_sec < timenow.tv_sec
 	      || (p->c_time.tv_sec == timenow.tv_sec
@@ -1368,7 +1368,7 @@ timeleft(tvp)
     if (callout == NULL)
 	return NULL;
 
-    gettimeofday(&timenow, NULL);
+    get_time(&timenow);
     tvp->tv_sec = callout->c_time.tv_sec - timenow.tv_sec;
     tvp->tv_usec = callout->c_time.tv_usec - timenow.tv_usec;
     if (tvp->tv_usec < 0) {

--- a/pppd/options.c
+++ b/pppd/options.c
@@ -801,6 +801,11 @@ process_option(opt, cmd, argv)
 		free(*optptr);
 	    *optptr = sv;
 	}
+	/* obfuscate original argument for things like password */
+	if (opt->flags & OPT_HIDE) {
+	    memset(*argv, '?', strlen(*argv));
+	    *argv = "********";
+	}
 	break;
 
     case o_special_noarg:

--- a/pppd/options.c
+++ b/pppd/options.c
@@ -1093,7 +1093,7 @@ showversion(argv)
     char **argv;
 {
     if (phase == PHASE_INITIALIZE) {
-	fprintf(stderr, "pppd version %s\n", VERSION);
+	fprintf(stdout, "pppd version %s\n", VERSION);
 	exit(0);
     }
     return 0;

--- a/pppd/plugins/passprompt.c
+++ b/pppd/plugins/passprompt.c
@@ -74,7 +74,7 @@ static int promptpass(char *user, char *passwd)
 	if (red == 0)
 	    break;
 	if (red < 0) {
-	    if (errno == EINTR)
+	    if (errno == EINTR && !got_sigterm)
 		continue;
 	    error("Can't read secret from %s: %m", promptprog);
 	    readgood = -1;
@@ -86,7 +86,7 @@ static int promptpass(char *user, char *passwd)
 
     /* now wait for child to exit */
     while (waitpid(kid, &wstat, 0) < 0) {
-	if (errno != EINTR) {
+	if (errno != EINTR || got_sigterm) {
 	    warn("error waiting for %s: %m", promptprog);
 	    break;
 	}

--- a/pppd/plugins/radius/buildreq.c
+++ b/pppd/plugins/radius/buildreq.c
@@ -293,7 +293,7 @@ int rc_acct_using_server(SERVER *acctserver,
 	SEND_DATA       data;
 	VALUE_PAIR	*adt_vp;
 	int		result;
-	time_t		start_time, dtime;
+	struct timeval	start_time, dtime;
 	char		msg[4096];
 	int		i;
 	int		timeout = rc_conf_int("radius_timeout");
@@ -320,11 +320,11 @@ int rc_acct_using_server(SERVER *acctserver,
 	 * Fill in Acct-Delay-Time
 	 */
 
-	dtime = 0;
-	if ((adt_vp = rc_avpair_add(&(data.send_pairs), PW_ACCT_DELAY_TIME, &dtime, 0, VENDOR_NONE)) == NULL)
+	dtime.tv_sec = 0;
+	if ((adt_vp = rc_avpair_add(&(data.send_pairs), PW_ACCT_DELAY_TIME, &dtime.tv_sec, 0, VENDOR_NONE)) == NULL)
 		return (ERROR_RC);
 
-	start_time = time(NULL);
+	get_time(&start_time);
 	result = ERROR_RC;
 	for(i=0; (i<acctserver->max) && (result != OK_RC) && (result != BADRESP_RC)
 		; i++)
@@ -336,8 +336,9 @@ int rc_acct_using_server(SERVER *acctserver,
 		rc_buildreq(&data, PW_ACCOUNTING_REQUEST, acctserver->name[i],
 			    acctserver->port[i], timeout, retries);
 
-		dtime = time(NULL) - start_time;
-		rc_avpair_assign(adt_vp, &dtime, 0);
+		get_time(&dtime);
+		dtime.tv_sec -= start_time.tv_sec;
+		rc_avpair_assign(adt_vp, &dtime.tv_sec, 0);
 
 		result = rc_send_server (&data, msg, NULL);
 	}

--- a/pppd/plugins/radius/config.c
+++ b/pppd/plugins/radius/config.c
@@ -273,7 +273,7 @@ char *rc_conf_str(char *optname)
 	option = find_option(optname, OT_STR);
 
 	if (option == NULL)
-		fatal("rc_conf_str: unkown config option requested: %s", optname);
+		fatal("rc_conf_str: unknown config option requested: %s", optname);
 	return (char *)option->val;
 }
 
@@ -284,7 +284,7 @@ int rc_conf_int(char *optname)
 	option = find_option(optname, OT_INT|OT_AUO);
 
 	if (option == NULL)
-		fatal("rc_conf_int: unkown config option requested: %s", optname);
+		fatal("rc_conf_int: unknown config option requested: %s", optname);
 	return *((int *)option->val);
 }
 
@@ -295,7 +295,7 @@ SERVER *rc_conf_srv(char *optname)
 	option = find_option(optname, OT_SRV);
 
 	if (option == NULL)
-		fatal("rc_conf_srv: unkown config option requested: %s", optname);
+		fatal("rc_conf_srv: unknown config option requested: %s", optname);
 	return (SERVER *)option->val;
 }
 

--- a/pppd/plugins/radius/sendserver.c
+++ b/pppd/plugins/radius/sendserver.c
@@ -302,7 +302,7 @@ int rc_send_server (SEND_DATA *data, char *msg, REQUEST_INFO *info)
 		FD_SET (sockfd, &readfds);
 		if (select (sockfd + 1, &readfds, NULL, NULL, &authtime) < 0)
 		{
-			if (errno == EINTR)
+			if (errno == EINTR && !got_sigterm)
 				continue;
 			error("rc_send_server: select: %m");
 			memset (secret, '\0', sizeof (secret));

--- a/pppd/plugins/rp-pppoe/discovery.c
+++ b/pppd/plugins/rp-pppoe/discovery.c
@@ -45,8 +45,8 @@ static int time_left(struct timeval *diff, struct timeval *exp)
 {
     struct timeval now;
 
-    if (gettimeofday(&now, NULL) < 0) {
-	error("gettimeofday: %m");
+    if (get_time(&now) < 0) {
+	error("get_time: %m");
 	return 0;
     }
 
@@ -353,8 +353,8 @@ waitForPADO(PPPoEConnection *conn, int timeout)
     conn->seenMaxPayload = 0;
     conn->error = 0;
 
-    if (gettimeofday(&expire_at, NULL) < 0) {
-	error("gettimeofday (waitForPADO): %m");
+    if (get_time(&expire_at) < 0) {
+	error("get_time (waitForPADO): %m");
 	return;
     }
     expire_at.tv_sec += timeout;
@@ -533,8 +533,8 @@ waitForPADS(PPPoEConnection *conn, int timeout)
     PPPoEPacket packet;
     int len;
 
-    if (gettimeofday(&expire_at, NULL) < 0) {
-	error("gettimeofday (waitForPADS): %m");
+    if (get_time(&expire_at) < 0) {
+	error("get_time (waitForPADS): %m");
 	return;
     }
     expire_at.tv_sec += timeout;

--- a/pppd/plugins/rp-pppoe/discovery.c
+++ b/pppd/plugins/rp-pppoe/discovery.c
@@ -369,7 +369,7 @@ waitForPADO(PPPoEConnection *conn, int timeout)
 
 	    while(1) {
 		r = select(conn->discoverySocket+1, &readable, NULL, NULL, &tv);
-		if (r >= 0 || errno != EINTR) break;
+		if (r >= 0 || errno != EINTR || got_sigterm) break;
 	    }
 	    if (r < 0) {
 		error("select (waitForPADO): %m");
@@ -550,7 +550,7 @@ waitForPADS(PPPoEConnection *conn, int timeout)
 
 	    while(1) {
 		r = select(conn->discoverySocket+1, &readable, NULL, NULL, &tv);
-		if (r >= 0 || errno != EINTR) break;
+		if (r >= 0 || errno != EINTR || got_sigterm) break;
 	    }
 	    if (r < 0) {
 		error("select (waitForPADS): %m");
@@ -622,7 +622,7 @@ discovery(PPPoEConnection *conn)
 
     do {
 	padiAttempts++;
-	if (padiAttempts > conn->discoveryAttempts) {
+	if (got_sigterm || padiAttempts > conn->discoveryAttempts) {
 	    warn("Timeout waiting for PADO packets");
 	    close(conn->discoverySocket);
 	    conn->discoverySocket = -1;
@@ -638,7 +638,7 @@ discovery(PPPoEConnection *conn)
     timeout = conn->discoveryTimeout;
     do {
 	padrAttempts++;
-	if (padrAttempts > conn->discoveryAttempts) {
+	if (got_sigterm || padrAttempts > conn->discoveryAttempts) {
 	    warn("Timeout waiting for PADS packets");
 	    close(conn->discoverySocket);
 	    conn->discoverySocket = -1;

--- a/pppd/plugins/winbind.c
+++ b/pppd/plugins/winbind.c
@@ -443,7 +443,7 @@ unsigned int run_ntlm_auth(const char *username,
                 return NOT_AUTHENTICATED;
         }
 
-	while ((wait(&status) == -1) && errno == EINTR)
+	while ((wait(&status) == -1) && errno == EINTR && !got_sigterm)
                 ;
 
 	if ((authenticated == AUTHENTICATED) && nt_key && !got_user_session_key) {

--- a/pppd/pppd.8
+++ b/pppd/pppd.8
@@ -570,6 +570,11 @@ to 1) if the \fIproxyarp\fR option is used, and will enable the
 dynamic IP address option (i.e. set /proc/sys/net/ipv4/ip_dynaddr to
 1) in demand mode if the local address changes.
 .TP
+.B lcp\-echo\-adaptive
+If this option is used with the \fIlcp\-echo\-failure\fR option then
+pppd will send LCP echo\-request frames only if no traffic was received
+from the peer since the last echo\-request was sent.
+.TP
 .B lcp\-echo\-failure \fIn
 If this option is given, pppd will presume the peer to be dead
 if \fIn\fR LCP echo\-requests are sent without receiving a valid LCP

--- a/pppd/pppd.8
+++ b/pppd/pppd.8
@@ -1854,6 +1854,11 @@ Simpson, W.A.
 .I PPP in HDLC-like Framing.
 July 1994.
 .TP
+.B RFC1990
+Sklower, K.; et al.,
+.I The PPP Multilink Protocol (MP).
+August 1996.
+.TP
 .B RFC2284
 Blunk, L.; Vollbrecht, J.,
 .I PPP Extensible Authentication Protocol (EAP).

--- a/pppd/pppd.h
+++ b/pppd/pppd.h
@@ -713,6 +713,8 @@ int  cipxfaddr __P((int));
 #endif
 int  get_if_hwaddr __P((u_char *addr, char *name));
 char *get_first_ethernet __P((void));
+int get_time __P((struct timeval *));
+				/* Get current time, monotonic if possible. */
 
 /* Procedures exported from options.c */
 int setipaddr __P((char *, char **, int)); /* Set local/remote ip addresses */

--- a/pppd/pppd.h
+++ b/pppd/pppd.h
@@ -223,6 +223,7 @@ struct notifier {
  * Global variables.
  */
 
+extern int	got_sigterm;	/* SIGINT or SIGTERM was received */
 extern int	hungup;		/* Physical layer has disconnected */
 extern int	ifunit;		/* Interface unit number */
 extern char	ifname[];	/* Interface name */

--- a/pppd/sys-solaris.c
+++ b/pppd/sys-solaris.c
@@ -114,6 +114,7 @@
 #include <sys/dlpi.h>
 #include <sys/stat.h>
 #include <sys/mkdev.h>
+#include <sys/time.h>
 #include <net/if.h>
 #include <net/if_arp.h>
 #include <net/route.h>
@@ -2862,4 +2863,14 @@ get_pty(master_fdp, slave_fdp, slave_name, uid)
     *slave_fdp = sfd;
 
     return 1;
+}
+
+/********************************************************************
+ *
+ * get_time - Get current time, monotonic if possible.
+ */
+int
+get_time(struct timeval *tv)
+{
+    return gettimeofday(tv, NULL);
 }

--- a/pppd/sys-solaris.c
+++ b/pppd/sys-solaris.c
@@ -2427,7 +2427,7 @@ dlpi_get_reply(fd, reply, expected_prim, maxlen)
     pfd.events = POLLIN | POLLPRI;
     do {
 	n = poll(&pfd, 1, 1000);
-    } while (n == -1 && errno == EINTR);
+    } while (n == -1 && errno == EINTR && !got_sigterm);
     if (n <= 0)
 	return -1;
 

--- a/pppd/tty.c
+++ b/pppd/tty.c
@@ -1071,7 +1071,7 @@ charshunt(ifd, ofd, record_file)
     pty_readable = stdin_readable = 1;
 
     ilevel = olevel = 0;
-    gettimeofday(&levelt, NULL);
+    get_time(&levelt);
     if (max_data_rate) {
 	max_level = max_data_rate / 10;
 	if (max_level < 100)
@@ -1120,7 +1120,7 @@ charshunt(ifd, ofd, record_file)
 	    int nbt;
 	    struct timeval now;
 
-	    gettimeofday(&now, NULL);
+	    get_time(&now);
 	    dt = (now.tv_sec - levelt.tv_sec
 		  + (now.tv_usec - levelt.tv_usec) / 1e6);
 	    nbt = (int)(dt * max_data_rate);

--- a/pppd/utils.c
+++ b/pppd/utils.c
@@ -835,7 +835,7 @@ complete_read(int fd, void *buf, size_t count)
 	for (done = 0; done < count; ) {
 		nb = read(fd, ptr, count - done);
 		if (nb < 0) {
-			if (errno == EINTR)
+			if (errno == EINTR && !got_sigterm)
 				continue;
 			return -1;
 		}

--- a/pppdump/pppdump.8
+++ b/pppdump/pppdump.8
@@ -13,6 +13,8 @@ pppdump \- convert PPP record file to readable format
 ]] [
 .B \-r
 ] [
+.B \-a
+] [
 .B \-m \fImru
 ] [
 .I file \fR...
@@ -53,6 +55,9 @@ or Deflate methods.
 Reverses the direction indicators, so that `sent' is printed for
 bytes or packets received, and `rcvd' is printed for bytes or packets
 sent.
+.TP
+.B \-a
+Prints absolute times.
 .TP
 .B \-m \fImru
 Use \fImru\fR as the MRU (maximum receive unit) for both directions of

--- a/pppstats/pppstats.8
+++ b/pppstats/pppstats.8
@@ -7,6 +7,8 @@ pppstats \- print PPP statistics
 [
 .B \-a
 ] [
+.B \-d
+] [
 .B \-v
 ] [
 .B \-r
@@ -40,6 +42,9 @@ Display absolute values rather than deltas.  With this option, all
 reports show statistics for the time since the link was initiated.
 Without this option, the second and subsequent reports show statistics
 for the time since the last report.
+.TP
+.B \-d
+Show data rate (kB/s) instead of bytes.
 .TP
 .B \-c \fIcount
 Repeat the display


### PR DESCRIPTION
Implementation based on the RFC: draft-kamath-pppext-eap-mschapv2-02.
Adding support for MSCHAPv2 inside extensible authentication protocol (EAP).

Original author: Thomas Omerzu <thomas@omerzu.de>.