### PR TITLE
Import lcp-echo-adaptive from openwrt.

### DIFF
--- a/pppd/lcp.c
+++ b/pppd/lcp.c
@@ -72,6 +72,7 @@ static void lcp_delayed_up __P((void *));
  */
 int	lcp_echo_interval = 0; 	/* Interval between LCP echo-requests */
 int	lcp_echo_fails = 0;	/* Tolerance to unanswered echo-requests */
+bool	lcp_echo_adaptive = 0;	/* request echo only if the link was idle */
 bool	lax_recv = 0;		/* accept control chars in asyncmap */
 bool	noendpoint = 0;		/* don't send/accept endpoint discriminator */
 
@@ -150,6 +151,8 @@ static option_t lcp_option_list[] = {
       OPT_PRIO },
     { "lcp-echo-interval", o_int, &lcp_echo_interval,
       "Set time in seconds between LCP echo requests", OPT_PRIO },
+    { "lcp-echo-adaptive", o_bool, &lcp_echo_adaptive,
+      "Suppress LCP echo requests if traffic was received", 1 },
     { "lcp-restart", o_int, &lcp_fsm[0].timeouttime,
       "Set time in seconds between LCP retransmissions", OPT_PRIO },
     { "lcp-max-terminate", o_int, &lcp_fsm[0].maxtermtransmits,
@@ -2327,6 +2330,22 @@ LcpSendEchoRequest (f)
         if (lcp_echos_pending >= lcp_echo_fails) {
             LcpLinkFailure(f);
 	    lcp_echos_pending = 0;
+	}
+    }
+
+    /*
+     * If adaptive echos have been enabled, only send the echo request if
+     * no traffic was received since the last one.
+     */
+    if (lcp_echo_adaptive) {
+	static unsigned int last_pkts_in = 0;
+
+	update_link_stats(f->unit);
+	link_stats_valid = 0;
+
+	if (link_stats.pkts_in != last_pkts_in) {
+	    last_pkts_in = link_stats.pkts_in;
+	    return;
 	}
     }
 

--- a/pppd/pppd.8
+++ b/pppd/pppd.8
@@ -570,6 +570,11 @@ to 1) if the \fIproxyarp\fR option is used, and will enable the
 dynamic IP address option (i.e. set /proc/sys/net/ipv4/ip_dynaddr to
 1) in demand mode if the local address changes.
 .TP
+.B lcp\-echo\-adaptive
+If this option is used with the \fIlcp\-echo\-failure\fR option then
+pppd will send LCP echo\-request frames only if no traffic was received
+from the peer since the last echo\-request was sent.
+.TP
 .B lcp\-echo\-failure \fIn
 If this option is given, pppd will presume the peer to be dead
 if \fIn\fR LCP echo\-requests are sent without receiving a valid LCP


### PR DESCRIPTION
Port Debians adaptive LCP echo patch to pppd, make it configurable and
enable it by default.

When adaptive LCP echo is enabled, LCP echo requests are only sent if the
link is idle, this avoids the common situation where a congested PPP link
(e.g. during torrenting) is falsely detected as disconnected because the
LCP replies are not received in time.

Signed-off-by: Marco d'Itri <md@linux.it>