### PR TITLE
pppd: Handle SIGINT and SIGTERM during interrupted syscalls

### DIFF
--- a/pppd/plugins/passprompt.c
+++ b/pppd/plugins/passprompt.c
@@ -74,7 +74,7 @@ static int promptpass(char *user, char *passwd)
 	if (red == 0)
 	    break;
 	if (red < 0) {
-	    if (errno == EINTR)
+	    if (errno == EINTR && !got_sigterm)
 		continue;
 	    error("Can't read secret from %s: %m", promptprog);
 	    readgood = -1;
@@ -86,7 +86,7 @@ static int promptpass(char *user, char *passwd)
 
     /* now wait for child to exit */
     while (waitpid(kid, &wstat, 0) < 0) {
-	if (errno != EINTR) {
+	if (errno != EINTR || got_sigterm) {
 	    warn("error waiting for %s: %m", promptprog);
 	    break;
 	}

--- a/pppd/plugins/radius/sendserver.c
+++ b/pppd/plugins/radius/sendserver.c
@@ -302,7 +302,7 @@ int rc_send_server (SEND_DATA *data, char *msg, REQUEST_INFO *info)
 		FD_SET (sockfd, &readfds);
 		if (select (sockfd + 1, &readfds, NULL, NULL, &authtime) < 0)
 		{
-			if (errno == EINTR)
+			if (errno == EINTR && !got_sigterm)
 				continue;
 			error("rc_send_server: select: %m");
 			memset (secret, '\0', sizeof (secret));

--- a/pppd/plugins/rp-pppoe/discovery.c
+++ b/pppd/plugins/rp-pppoe/discovery.c
@@ -369,7 +369,7 @@ waitForPADO(PPPoEConnection *conn, int timeout)
 
 	    while(1) {
 		r = select(conn->discoverySocket+1, &readable, NULL, NULL, &tv);
-		if (r >= 0 || errno != EINTR) break;
+		if (r >= 0 || errno != EINTR || got_sigterm) break;
 	    }
 	    if (r < 0) {
 		error("select (waitForPADO): %m");
@@ -550,7 +550,7 @@ waitForPADS(PPPoEConnection *conn, int timeout)
 
 	    while(1) {
 		r = select(conn->discoverySocket+1, &readable, NULL, NULL, &tv);
-		if (r >= 0 || errno != EINTR) break;
+		if (r >= 0 || errno != EINTR || got_sigterm) break;
 	    }
 	    if (r < 0) {
 		error("select (waitForPADS): %m");
@@ -622,7 +622,7 @@ discovery(PPPoEConnection *conn)
 
     do {
 	padiAttempts++;
-	if (padiAttempts > conn->discoveryAttempts) {
+	if (got_sigterm || padiAttempts > conn->discoveryAttempts) {
 	    warn("Timeout waiting for PADO packets");
 	    close(conn->discoverySocket);
 	    conn->discoverySocket = -1;
@@ -638,7 +638,7 @@ discovery(PPPoEConnection *conn)
     timeout = conn->discoveryTimeout;
     do {
 	padrAttempts++;
-	if (padrAttempts > conn->discoveryAttempts) {
+	if (got_sigterm || padrAttempts > conn->discoveryAttempts) {
 	    warn("Timeout waiting for PADS packets");
 	    close(conn->discoverySocket);
 	    conn->discoverySocket = -1;

--- a/pppd/plugins/winbind.c
+++ b/pppd/plugins/winbind.c
@@ -443,7 +443,7 @@ unsigned int run_ntlm_auth(const char *username,
                 return NOT_AUTHENTICATED;
         }
 
-	while ((wait(&status) == -1) && errno == EINTR)
+	while ((wait(&status) == -1) && errno == EINTR && !got_sigterm)
                 ;
 
 	if ((authenticated == AUTHENTICATED) && nt_key && !got_user_session_key) {

--- a/pppd/pppd.h
+++ b/pppd/pppd.h
@@ -223,6 +223,7 @@ struct notifier {
  * Global variables.
  */
 
+extern int	got_sigterm;	/* SIGINT or SIGTERM was received */
 extern int	hungup;		/* Physical layer has disconnected */
 extern int	ifunit;		/* Interface unit number */
 extern char	ifname[];	/* Interface name */

--- a/pppd/sys-solaris.c
+++ b/pppd/sys-solaris.c
@@ -2426,7 +2426,7 @@ dlpi_get_reply(fd, reply, expected_prim, maxlen)
     pfd.events = POLLIN | POLLPRI;
     do {
 	n = poll(&pfd, 1, 1000);
-    } while (n == -1 && errno == EINTR);
+    } while (n == -1 && errno == EINTR && !got_sigterm);
     if (n <= 0)
 	return -1;
 

--- a/pppd/utils.c
+++ b/pppd/utils.c
@@ -835,7 +835,7 @@ complete_read(int fd, void *buf, size_t count)
 	for (done = 0; done < count; ) {
 		nb = read(fd, ptr, count - done);
 		if (nb < 0) {
-			if (errno == EINTR)
+			if (errno == EINTR && !got_sigterm)
 				continue;
 			return -1;
 		}


### PR DESCRIPTION
When pppd receives SIGINT or SIGTERM it should handle it and not try to
restart interrupted syscall.

This change fixes problem that pppd cannot be terminated by SIGINT or
SIGTERM signal when pppd plugins are used.