### PR TITLE
Disable asking password again when prompt return 128 (quit connection)

### DIFF
--- a/pppd/plugins/passprompt.c
+++ b/pppd/plugins/passprompt.c
@@ -32,7 +32,7 @@ static int promptpass(char *user, char *passwd)
     int readgood, wstat;
     ssize_t red;
 
-    if (promptprog[0] == 0 || access(promptprog, X_OK) < 0)
+    if (asked_to_quit || promptprog[0] == 0 || access(promptprog, X_OK) < 0)
 	return -1;	/* sorry, can't help */
 
     if (!passwd)
@@ -97,9 +97,14 @@ static int promptpass(char *user, char *passwd)
     passwd[readgood] = 0;
     if (!WIFEXITED(wstat))
 	warn("%s terminated abnormally", promptprog);
-    if (WEXITSTATUS(wstat))
-	warn("%s exited with code %d", promptprog, WEXITSTATUS(status));
-
+    if (WEXITSTATUS(wstat)) {
+	warn("%s exited with code %d", promptprog, WEXITSTATUS(wstat));
+	/* code when program asked to quit */
+	if (WEXITSTATUS(wstat) == 128) {
+		asked_to_quit = 1;
+	}
+	return -1;
+    }
     return 1;
 }
 

--- a/pppd/pppd.h
+++ b/pppd/pppd.h
@@ -230,6 +230,7 @@ extern char	hostname[];	/* Our hostname */
 extern u_char	outpacket_buf[]; /* Buffer for outgoing packets */
 extern int	devfd;		/* fd of underlying device */
 extern int	fd_ppp;		/* fd for talking PPP */
+extern int	asked_to_quit;  /* Somewhere in the program we got signal to quit pppd */
 extern int	phase;		/* Current state of link - see values below */
 extern int	baud_rate;	/* Current link speed in bits/sec */
 extern char	*progname;	/* Name of this program */

--- a/pppd/tty.c
+++ b/pppd/tty.c
@@ -153,7 +153,6 @@ int	using_pty = 0;		/* we're allocating a pty as the device */
 
 extern uid_t uid;
 extern int kill_link;
-extern int asked_to_quit;
 extern int got_sigterm;
 
 /* XXX */


### PR DESCRIPTION
Greetings!
There is a suggestion coming from our group.
There's the password prompt plugin, and it might be asking for a password up to 10 times.
But what if the one using the callback app hits cancel or whatever and does not want to enter the password?
That would be nice to let the plugin know, that no more requests are needed.
For this we proposed the 128 return code but it can be whatever you prefer.

What do you think of that?