### PR TITLE
Accept Malformed Windows Success Message

### DIFF
--- a/pppd/chap_ms.c
+++ b/pppd/chap_ms.c
@@ -423,6 +423,8 @@ chapms2_check_success(int id, unsigned char *msg, int len)
 	len -= MS_AUTH_RESPONSE_LENGTH;
 	if ((len >= 3) && !strncmp((char *)msg, " M=", 3)) {
 		msg += 3; /* Eat the delimiter */
+	} else 	if ((len >= 2) && !strncmp((char *)msg, "M=", 2)) {
+		msg += 2; /* Eat the delimiter */
 	} else if (len) {
 		/* Packet has extra text which does not begin " M=" */
 		error("MS-CHAPv2 Success packet is badly formed.");


### PR DESCRIPTION
Windows Server 2019 skip a space when sending a success message.
This commit accepts such a malformed message and continues normally.

Signed-off-by: Yannay Linveh <yannayl@gmail.com>