### PR TITLE
pppd: Add client CHAP authentication timeout

### DIFF
--- a/pppd/pppd.8
+++ b/pppd/pppd.8
@@ -277,6 +277,9 @@ Set the maximum number of CHAP challenge transmissions to \fIn\fR
 Set the CHAP restart interval (retransmission timeout for challenges)
 to \fIn\fR seconds (default 3).
 .TP
+.B chap-timeout \fIn
+Set timeout for CHAP authentication by peer to \fIn\fR seconds (default 60).
+.TP
 .B child\-timeout \fIn
 When exiting, wait for up to \fIn\fR seconds for any child processes
 (such as the command specified with the \fBpty\fR command) to exit


### PR DESCRIPTION
If CHAP authentication is required with the peer but this is never
completed (either because the server never sends the challenge or
because the client doesn't receive the outcome) then the client
will wait forever, relying on the server to terminate the connection.

There are options for server side retries but a client side timeout
option is required to prevent the client from getting stuck if the
server won't terminate the connection. This is defaulted to 60 seconds.

----

>  I think it would be better to resend the CHAP-Response packet, instead of just giving up.

The client can't send a `CHAP Response` if it never received a `CHAP Challenge`. The server may not resend this or the retries may also be lost, so the client must timeout in this scenario.

The server may not accept a duplicate `CHAP Response` a full 60 seconds later, especially when it has already sent a `CHAP Success`.  This would add an assumption about how the other side of the link will behave. It looks like `ppp` would do this, but RFC 1334 does not require it. Only PAP explicitly specifies that retries will occur indefinitely.

----

I'd really like to get this merged to fix the problem where pppd hangs indefinitely when a single `CHAP Challenge` or `CHAP Success` packet is lost (#87).