### PR TITLE
Fix setting prefix for IPv6 link-local addresses

### DIFF
--- a/pppd/sys-linux.c
+++ b/pppd/sys-linux.c
@@ -2757,7 +2757,7 @@ int sif6addr (int unit, eui64_t our_eui64, eui64_t his_eui64)
     memset(&ifr6, 0, sizeof(ifr6));
     IN6_LLADDR_FROM_EUI64(ifr6.ifr6_addr, our_eui64);
     ifr6.ifr6_ifindex = ifr.ifr_ifindex;
-    ifr6.ifr6_prefixlen = 10;
+    ifr6.ifr6_prefixlen = 128;
 
     if (ioctl(sock6_fd, SIOCSIFADDR, &ifr6) < 0) {
 	error("sif6addr: ioctl(SIOCSIFADDR): %m (line %d)", __LINE__);
@@ -2768,7 +2768,7 @@ int sif6addr (int unit, eui64_t our_eui64, eui64_t his_eui64)
     memset(&rt6, 0, sizeof(rt6));
     IN6_LLADDR_FROM_EUI64(rt6.rtmsg_dst, his_eui64);
     rt6.rtmsg_flags = RTF_UP;
-    rt6.rtmsg_dst_len = 10;
+    rt6.rtmsg_dst_len = 128;
     rt6.rtmsg_ifindex = ifr.ifr_ifindex;
     rt6.rtmsg_metric = 1;
 
@@ -2805,7 +2805,7 @@ int cif6addr (int unit, eui64_t our_eui64, eui64_t his_eui64)
     memset(&ifr6, 0, sizeof(ifr6));
     IN6_LLADDR_FROM_EUI64(ifr6.ifr6_addr, our_eui64);
     ifr6.ifr6_ifindex = ifr.ifr_ifindex;
-    ifr6.ifr6_prefixlen = 10;
+    ifr6.ifr6_prefixlen = 128;
 
     if (ioctl(sock6_fd, SIOCDIFADDR, &ifr6) < 0) {
 	if (errno != EADDRNOTAVAIL) {


### PR DESCRIPTION
PPP IPV6CP protocol exchanges only IPv6 Interface Identifiers which are
used for generating IPv6 link-local addresses. As on PPP link cannot be
more hosts and IPv6 link-local addresses are designed for addressing a
single link, set route prefix for local and remote IPv6 link-local
addresses to /128 which means single IPv6 address.

This ensures that Linux kernel would not try to route other IPv6 link-local
addresses over PPP link.

Routable IPv6 prefix on PPP link is later configured either by ICMPv6
Router Advertisement packets or manually/statically. Routable local IPv6
address is then assigned by SLAAC, DHCPv6 or manual/static configuration.

So this change has no effect for routable IPv6 address or routable IPv6
prefix.

Note that pppd for IPv4 already sets netmask to 255.255.255.255, one single
IPv4 address.

Fixes: https://github.com/paulusmack/ppp/issues/121