### PR TITLE
pppd: remove __P

### DIFF
--- a/chat/chat.c
+++ b/chat/chat.c
@@ -121,17 +121,14 @@ static const char rcsid[] = "$Id: chat.c,v 1.30 2004/01/17 05:47:55 carlsonj Exp
 #define SIGTYPE void
 #endif
 
-#undef __P
 #undef __V
 
 #ifdef __STDC__
 #include <stdarg.h>
 #define __V(x)	x
-#define __P(x)	x
 #else
 #include <varargs.h>
 #define __V(x)	(va_alist) va_dcl
-#define __P(x)	()
 #define const
 #endif
 
@@ -209,39 +206,39 @@ int clear_report_next = 0;
 
 int say_next = 0, hup_next = 0;
 
-void *dup_mem __P((void *b, size_t c));
-void *copy_of __P((char *s));
-char *grow __P((char *s, char **p, size_t len));
-void usage __P((void));
-void msgf __P((const char *fmt, ...));
-void fatal __P((int code, const char *fmt, ...));
-SIGTYPE sigalrm __P((int signo));
-SIGTYPE sigint __P((int signo));
-SIGTYPE sigterm __P((int signo));
-SIGTYPE sighup __P((int signo));
-void unalarm __P((void));
-void init __P((void));
-void set_tty_parameters __P((void));
-void echo_stderr __P((int));
-void break_sequence __P((void));
-void terminate __P((int status));
-void do_file __P((char *chat_file));
-int  get_string __P((register char *string));
-int  put_string __P((register char *s));
-int  write_char __P((int c));
-int  put_char __P((int c));
-int  get_char __P((void));
-void chat_send __P((register char *s));
-char *character __P((int c));
-void chat_expect __P((register char *s));
-char *clean __P((register char *s, int sending));
-void break_sequence __P((void));
-void terminate __P((int status));
-void pack_array __P((char **array, int end));
-char *expect_strtok __P((char *, char *));
-int vfmtmsg __P((char *, int, const char *, va_list));	/* vsprintf++ */
+void *dup_mem(void *b, size_t c);
+void *copy_of(char *s);
+char *grow(char *s, char **p, size_t len);
+void usage(void);
+void msgf(const char *fmt, ...);
+void fatal(int code, const char *fmt, ...);
+SIGTYPE sigalrm(int signo);
+SIGTYPE sigint(int signo);
+SIGTYPE sigterm(int signo);
+SIGTYPE sighup(int signo);
+void unalarm(void);
+void init(void);
+void set_tty_parameters(void);
+void echo_stderr(int);
+void break_sequence(void);
+void terminate(int status);
+void do_file(char *chat_file);
+int  get_string(register char *string);
+int  put_string(register char *s);
+int  write_char(int c);
+int  put_char(int c);
+int  get_char(void);
+void chat_send(register char *s);
+char *character(int c);
+void chat_expect(register char *s);
+char *clean(register char *s, int sending);
+void break_sequence(void);
+void terminate(int status);
+void pack_array(char **array, int end);
+char *expect_strtok(char *, char *);
+int vfmtmsg(char *, int, const char *, va_list);	/* vsprintf++ */
 
-int main __P((int, char *[]));
+int main(int, char *[]);
 
 void *dup_mem(b, c)
 void *b;

--- a/include/linux/ppp_defs.h
+++ b/include/linux/ppp_defs.h
@@ -184,12 +184,4 @@ struct ppp_idle {
     time_t recv_idle;		/* time since last NP packet received */
 };
 
-#ifndef __P
-#ifdef __STDC__
-#define __P(x)	x
-#else
-#define __P(x)	()
-#endif
-#endif
-
 #endif /* _PPP_DEFS_H_ */

--- a/include/net/if_ppp.h
+++ b/include/net/if_ppp.h
@@ -150,7 +150,7 @@ struct ifpppcstatsreq {
 #endif
 
 #if (defined(_KERNEL) || defined(KERNEL)) && !defined(NeXT)
-void pppattach __P((void));
-void pppintr __P((void));
+void pppattach(void);
+void pppintr(void);
 #endif
 #endif /* _IF_PPP_H_ */

--- a/include/net/ppp-comp.h
+++ b/include/net/ppp-comp.h
@@ -59,36 +59,36 @@ struct compressor {
 	int	compress_proto;	/* CCP compression protocol number */
 
 	/* Allocate space for a compressor (transmit side) */
-	void	*(*comp_alloc) __P((u_char *options, int opt_len));
+	void	*(*comp_alloc)(u_char *options, int opt_len);
 	/* Free space used by a compressor */
-	void	(*comp_free) __P((void *state));
+	void	(*comp_free)(void *state);
 	/* Initialize a compressor */
-	int	(*comp_init) __P((void *state, u_char *options, int opt_len,
-				  int unit, int hdrlen, int debug));
+	int	(*comp_init)(void *state, u_char *options, int opt_len,
+				  int unit, int hdrlen, int debug);
 	/* Reset a compressor */
-	void	(*comp_reset) __P((void *state));
+	void	(*comp_reset)(void *state);
 	/* Compress a packet */
-	int	(*compress) __P((void *state, PACKETPTR *mret,
-				 PACKETPTR mp, int orig_len, int max_len));
+	int	(*compress)(void *state, PACKETPTR *mret,
+				 PACKETPTR mp, int orig_len, int max_len);
 	/* Return compression statistics */
-	void	(*comp_stat) __P((void *state, struct compstat *stats));
+	void	(*comp_stat)(void *state, struct compstat *stats);
 
 	/* Allocate space for a decompressor (receive side) */
-	void	*(*decomp_alloc) __P((u_char *options, int opt_len));
+	void	*(*decomp_alloc)(u_char *options, int opt_len);
 	/* Free space used by a decompressor */
-	void	(*decomp_free) __P((void *state));
+	void	(*decomp_free)(void *state);
 	/* Initialize a decompressor */
-	int	(*decomp_init) __P((void *state, u_char *options, int opt_len,
-				    int unit, int hdrlen, int mru, int debug));
+	int	(*decomp_init)(void *state, u_char *options, int opt_len,
+				    int unit, int hdrlen, int mru, int debug);
 	/* Reset a decompressor */
-	void	(*decomp_reset) __P((void *state));
+	void	(*decomp_reset)(void *state);
 	/* Decompress a packet. */
-	int	(*decompress) __P((void *state, PACKETPTR mp,
-				   PACKETPTR *dmpp));
+	int	(*decompress)(void *state, PACKETPTR mp,
+				   PACKETPTR *dmpp);
 	/* Update state for an incompressible packet received */
-	void	(*incomp) __P((void *state, PACKETPTR mp));
+	void	(*incomp)(void *state, PACKETPTR mp);
 	/* Return decompression statistics */
-	void	(*decomp_stat) __P((void *state, struct compstat *stats));
+	void	(*decomp_stat)(void *state, struct compstat *stats);
 };
 #endif /* PACKETPTR */
 

--- a/include/net/ppp_defs.h
+++ b/include/net/ppp_defs.h
@@ -183,12 +183,4 @@ struct ppp_idle {
     time_t recv_idle;		/* time since last NP packet received */
 };
 
-#ifndef __P
-#ifdef __STDC__
-#define __P(x)	x
-#else
-#define __P(x)	()
-#endif
-#endif
-
 #endif /* _PPP_DEFS_H_ */

--- a/include/net/slcompress.h
+++ b/include/net/slcompress.h
@@ -137,12 +137,12 @@ struct slcompress {
 /* flag values */
 #define SLF_TOSS 1		/* tossing rcvd frames because of input err */
 
-void	sl_compress_init __P((struct slcompress *));
-void	sl_compress_setup __P((struct slcompress *, int));
-u_int	sl_compress_tcp __P((struct mbuf *,
-	    struct ip *, struct slcompress *, int));
-int	sl_uncompress_tcp __P((u_char **, int, u_int, struct slcompress *));
-int	sl_uncompress_tcp_core __P((u_char *, int, int, u_int,
-	    struct slcompress *, u_char **, u_int *));
+void	sl_compress_init(struct slcompress *);
+void	sl_compress_setup(struct slcompress *, int);
+u_int	sl_compress_tcp(struct mbuf *,
+	    struct ip *, struct slcompress *, int);
+int	sl_uncompress_tcp(u_char **, int, u_int, struct slcompress *);
+int	sl_uncompress_tcp_core(u_char *, int, int, u_int,
+	    struct slcompress *, u_char **, u_int *);
 
 #endif /* _SLCOMPRESS_H_ */

--- a/include/net/vjcompress.h
+++ b/include/net/vjcompress.h
@@ -130,15 +130,15 @@ struct vjcompress {
 /* flag values */
 #define VJF_TOSS 1		/* tossing rcvd frames because of input err */
 
-extern void  vj_compress_init __P((struct vjcompress *comp, int max_state));
-extern u_int vj_compress_tcp __P((struct ip *ip, u_int mlen,
+extern void  vj_compress_init(struct vjcompress *comp, int max_state);
+extern u_int vj_compress_tcp(struct ip *ip, u_int mlen,
 				struct vjcompress *comp, int compress_cid_flag,
-				u_char **vjhdrp));
-extern void  vj_uncompress_err __P((struct vjcompress *comp));
-extern int   vj_uncompress_uncomp __P((u_char *buf, int buflen,
-				struct vjcompress *comp));
-extern int   vj_uncompress_tcp __P((u_char *buf, int buflen, int total_len,
+				u_char **vjhdrp);
+extern void  vj_uncompress_err(struct vjcompress *comp);
+extern int   vj_uncompress_uncomp(u_char *buf, int buflen,
+				struct vjcompress *comp);
+extern int   vj_uncompress_tcp(u_char *buf, int buflen, int total_len,
 				struct vjcompress *comp, u_char **hdrp,
-				u_int *hlenp));
+				u_int *hlenp);
 
 #endif /* _VJCOMPRESS_H_ */

--- a/modules/bsd-comp.c
+++ b/modules/bsd-comp.c
@@ -148,19 +148,19 @@ struct bsd_db {
 #define BSD_OVHD	2		/* BSD compress overhead/packet */
 #define BSD_INIT_BITS	BSD_MIN_BITS
 
-static void	*bsd_comp_alloc __P((u_char *options, int opt_len));
-static void	*bsd_decomp_alloc __P((u_char *options, int opt_len));
-static void	bsd_free __P((void *state));
-static int	bsd_comp_init __P((void *state, u_char *options, int opt_len,
-				   int unit, int hdrlen, int debug));
-static int	bsd_decomp_init __P((void *state, u_char *options, int opt_len,
-				     int unit, int hdrlen, int mru, int debug));
-static int	bsd_compress __P((void *state, mblk_t **mret,
-				  mblk_t *mp, int slen, int maxolen));
-static void	bsd_incomp __P((void *state, mblk_t *dmsg));
-static int	bsd_decompress __P((void *state, mblk_t *cmp, mblk_t **dmpp));
-static void	bsd_reset __P((void *state));
-static void	bsd_comp_stats __P((void *state, struct compstat *stats));
+static void	*bsd_comp_alloc(u_char *options, int opt_len);
+static void	*bsd_decomp_alloc(u_char *options, int opt_len);
+static void	bsd_free(void *state);
+static int	bsd_comp_init(void *state, u_char *options, int opt_len,
+				   int unit, int hdrlen, int debug);
+static int	bsd_decomp_init(void *state, u_char *options, int opt_len,
+				     int unit, int hdrlen, int mru, int debug);
+static int	bsd_compress(void *state, mblk_t **mret,
+				  mblk_t *mp, int slen, int maxolen);
+static void	bsd_incomp(void *state, mblk_t *dmsg);
+static int	bsd_decompress(void *state, mblk_t *cmp, mblk_t **dmpp);
+static void	bsd_reset(void *state);
+static void	bsd_comp_stats(void *state, struct compstat *stats);
 
 /*
  * Procedures exported to ppp_comp.c.

--- a/modules/deflate.c
+++ b/modules/deflate.c
@@ -80,25 +80,25 @@ struct deflate_state {
 
 #define DEFLATE_OVHD	2		/* Deflate overhead/packet */
 
-static void	*z_alloc __P((void *, u_int items, u_int size));
-static void	*z_alloc_init __P((void *, u_int items, u_int size));
-static void	z_free __P((void *, void *ptr));
-static void	*z_comp_alloc __P((u_char *options, int opt_len));
-static void	*z_decomp_alloc __P((u_char *options, int opt_len));
-static void	z_comp_free __P((void *state));
-static void	z_decomp_free __P((void *state));
-static int	z_comp_init __P((void *state, u_char *options, int opt_len,
-				 int unit, int hdrlen, int debug));
-static int	z_decomp_init __P((void *state, u_char *options, int opt_len,
-				     int unit, int hdrlen, int mru, int debug));
-static int	z_compress __P((void *state, mblk_t **mret,
-				  mblk_t *mp, int slen, int maxolen));
-static void	z_incomp __P((void *state, mblk_t *dmsg));
-static int	z_decompress __P((void *state, mblk_t *cmp,
-				    mblk_t **dmpp));
-static void	z_comp_reset __P((void *state));
-static void	z_decomp_reset __P((void *state));
-static void	z_comp_stats __P((void *state, struct compstat *stats));
+static void	*z_alloc(void *, u_int items, u_int size);
+static void	*z_alloc_init(void *, u_int items, u_int size);
+static void	z_free(void *, void *ptr);
+static void	*z_comp_alloc(u_char *options, int opt_len);
+static void	*z_decomp_alloc(u_char *options, int opt_len);
+static void	z_comp_free(void *state);
+static void	z_decomp_free(void *state);
+static int	z_comp_init(void *state, u_char *options, int opt_len,
+				 int unit, int hdrlen, int debug);
+static int	z_decomp_init(void *state, u_char *options, int opt_len,
+				     int unit, int hdrlen, int mru, int debug);
+static int	z_compress(void *state, mblk_t **mret,
+				  mblk_t *mp, int slen, int maxolen);
+static void	z_incomp(void *state, mblk_t *dmsg);
+static int	z_decompress(void *state, mblk_t *cmp,
+				    mblk_t **dmpp);
+static void	z_comp_reset(void *state);
+static void	z_decomp_reset(void *state);
+static void	z_comp_stats(void *state, struct compstat *stats);
 
 /*
  * Procedures exported to ppp_comp.c.

--- a/modules/if_ppp.c
+++ b/modules/if_ppp.c
@@ -80,10 +80,10 @@
 
 #define ifr_mtu		ifr_metric
 
-static int if_ppp_open __P((queue_t *, int, int, int));
-static int if_ppp_close __P((queue_t *, int));
-static int if_ppp_wput __P((queue_t *, mblk_t *));
-static int if_ppp_rput __P((queue_t *, mblk_t *));
+static int if_ppp_open(queue_t *, int, int, int);
+static int if_ppp_close(queue_t *, int);
+static int if_ppp_wput(queue_t *, mblk_t *);
+static int if_ppp_rput(queue_t *, mblk_t *);
 
 #define PPP_IF_ID 0x8021
 static struct module_info minfo = {
@@ -117,11 +117,11 @@ static int ppp_nalloc;		/* Number of elements of ifs and states */
 static struct ifnet **ifs;	/* Array of pointers to interface structs */
 static if_ppp_t **states;	/* Array of pointers to state structs */
 
-static int if_ppp_output __P((struct ifnet *, struct mbuf *,
-			      struct sockaddr *));
-static int if_ppp_ioctl __P((struct ifnet *, u_int, caddr_t));
-static struct mbuf *make_mbufs __P((mblk_t *, int));
-static mblk_t *make_message __P((struct mbuf *, int));
+static int if_ppp_output(struct ifnet *, struct mbuf *,
+			      struct sockaddr *);
+static int if_ppp_ioctl(struct ifnet *, u_int, caddr_t);
+static struct mbuf *make_mbufs(mblk_t *, int);
+static mblk_t *make_message(struct mbuf *, int);
 
 #ifdef SNIT_SUPPORT
 /* Fake ether header for SNIT */
@@ -129,7 +129,7 @@ static struct ether_header snit_ehdr = {{0}, {0}, ETHERTYPE_IP};
 #endif
 
 #ifndef __osf__
-static void ppp_if_detach __P((struct ifnet *));
+static void ppp_if_detach(struct ifnet *);
 
 /*
  * Detach all the interfaces before unloading.

--- a/modules/ppp.c
+++ b/modules/ppp.c
@@ -85,12 +85,6 @@
 
 #include <netinet/in.h>	/* leave this outside of PRIOQ for htons */
 
-#ifdef __STDC__
-#define __P(x)	x
-#else
-#define __P(x)	()
-#endif
-
 /*
  * The IP module may use this SAP value for IP packets.
  */
@@ -254,43 +248,43 @@ static upperstr_t *minor_devs = NULL;
 static upperstr_t *ppas = NULL;
 
 #ifdef SVR4
-static int pppopen __P((queue_t *, dev_t *, int, int, cred_t *));
-static int pppclose __P((queue_t *, int, cred_t *));
+static int pppopen(queue_t *, dev_t *, int, int, cred_t *);
+static int pppclose(queue_t *, int, cred_t *);
 #else
-static int pppopen __P((queue_t *, int, int, int));
-static int pppclose __P((queue_t *, int));
+static int pppopen(queue_t *, int, int, int);
+static int pppclose(queue_t *, int);
 #endif /* SVR4 */
-static int pppurput __P((queue_t *, mblk_t *));
-static int pppuwput __P((queue_t *, mblk_t *));
-static int pppursrv __P((queue_t *));
-static int pppuwsrv __P((queue_t *));
-static int ppplrput __P((queue_t *, mblk_t *));
-static int ppplwput __P((queue_t *, mblk_t *));
-static int ppplrsrv __P((queue_t *));
-static int ppplwsrv __P((queue_t *));
+static int pppurput(queue_t *, mblk_t *);
+static int pppuwput(queue_t *, mblk_t *);
+static int pppursrv(queue_t *);
+static int pppuwsrv(queue_t *);
+static int ppplrput(queue_t *, mblk_t *);
+static int ppplwput(queue_t *, mblk_t *);
+static int ppplrsrv(queue_t *);
+static int ppplwsrv(queue_t *);
 #ifndef NO_DLPI
-static void dlpi_request __P((queue_t *, mblk_t *, upperstr_t *));
-static void dlpi_error __P((queue_t *, upperstr_t *, int, int, int));
-static void dlpi_ok __P((queue_t *, int));
+static void dlpi_request(queue_t *, mblk_t *, upperstr_t *);
+static void dlpi_error(queue_t *, upperstr_t *, int, int, int);
+static void dlpi_ok(queue_t *, int);
 #endif
-static int send_data __P((mblk_t *, upperstr_t *));
-static void new_ppa __P((queue_t *, mblk_t *));
-static void attach_ppa __P((queue_t *, mblk_t *));
-static void detach_ppa __P((queue_t *, mblk_t *));
-static void detach_lower __P((queue_t *, mblk_t *));
-static void debug_dump __P((queue_t *, mblk_t *));
-static upperstr_t *find_dest __P((upperstr_t *, int));
+static int send_data(mblk_t *, upperstr_t *);
+static void new_ppa(queue_t *, mblk_t *);
+static void attach_ppa(queue_t *, mblk_t *);
+static void detach_ppa(queue_t *, mblk_t *);
+static void detach_lower(queue_t *, mblk_t *);
+static void debug_dump(queue_t *, mblk_t *);
+static upperstr_t *find_dest(upperstr_t *, int);
 #if defined(SOL2)
-static upperstr_t *find_promisc __P((upperstr_t *, int));
-static mblk_t *prepend_ether __P((upperstr_t *, mblk_t *, int));
-static mblk_t *prepend_udind __P((upperstr_t *, mblk_t *, int));
-static void promisc_sendup __P((upperstr_t *, mblk_t *, int, int));
+static upperstr_t *find_promisc(upperstr_t *, int);
+static mblk_t *prepend_ether(upperstr_t *, mblk_t *, int);
+static mblk_t *prepend_udind(upperstr_t *, mblk_t *, int);
+static void promisc_sendup(upperstr_t *, mblk_t *, int, int);
 #endif /* defined(SOL2) */
-static int putctl2 __P((queue_t *, int, int, int));
-static int putctl4 __P((queue_t *, int, int, int));
-static int pass_packet __P((upperstr_t *ppa, mblk_t *mp, int outbound));
+static int putctl2(queue_t *, int, int, int);
+static int putctl4(queue_t *, int, int, int);
+static int pass_packet(upperstr_t *ppa, mblk_t *mp, int outbound);
 #ifdef FILTER_PACKETS
-static int ip_hard_filter __P((upperstr_t *ppa, mblk_t *mp, int outbound));
+static int ip_hard_filter(upperstr_t *ppa, mblk_t *mp, int outbound);
 #endif /* FILTER_PACKETS */
 
 #define PPP_ID 0xb1a6

--- a/modules/ppp_ahdlc.c
+++ b/modules/ppp_ahdlc.c
@@ -107,11 +107,11 @@ typedef unsigned int            uintpointer_t;
 
 MOD_OPEN_DECL(ahdlc_open);
 MOD_CLOSE_DECL(ahdlc_close);
-static int ahdlc_wput __P((queue_t *, mblk_t *));
-static int ahdlc_rput __P((queue_t *, mblk_t *));
-static void ahdlc_encode __P((queue_t *, mblk_t *));
-static void ahdlc_decode __P((queue_t *, mblk_t *));
-static int msg_byte __P((mblk_t *, unsigned int));
+static int ahdlc_wput(queue_t *, mblk_t *);
+static int ahdlc_rput(queue_t *, mblk_t *);
+static void ahdlc_encode(queue_t *, mblk_t *);
+static void ahdlc_decode(queue_t *, mblk_t *);
+static int msg_byte(mblk_t *, unsigned int);
 
 #if defined(SOL2)
 /*

--- a/modules/ppp_comp.c
+++ b/modules/ppp_comp.c
@@ -74,12 +74,12 @@
 
 MOD_OPEN_DECL(ppp_comp_open);
 MOD_CLOSE_DECL(ppp_comp_close);
-static int ppp_comp_rput __P((queue_t *, mblk_t *));
-static int ppp_comp_rsrv __P((queue_t *));
-static int ppp_comp_wput __P((queue_t *, mblk_t *));
-static int ppp_comp_wsrv __P((queue_t *));
-static void ppp_comp_ccp __P((queue_t *, mblk_t *, int));
-static int msg_byte __P((mblk_t *, unsigned int));
+static int ppp_comp_rput(queue_t *, mblk_t *);
+static int ppp_comp_rsrv(queue_t *);
+static int ppp_comp_wput(queue_t *, mblk_t *);
+static int ppp_comp_wsrv(queue_t *);
+static void ppp_comp_ccp(queue_t *, mblk_t *, int);
+static int msg_byte(mblk_t *, unsigned int);
 
 /* Extract byte i of message mp. */
 #define MSG_BYTE(mp, i)	((i) < (mp)->b_wptr - (mp)->b_rptr? (mp)->b_rptr[i]: \
@@ -118,7 +118,7 @@ int ppp_comp_count;		/* number of module instances in use */
 
 #ifdef __osf__
 
-static void ppp_comp_alloc __P((comp_state_t *));
+static void ppp_comp_alloc(comp_state_t *);
 typedef struct memreq {
     unsigned char comp_opts[20];
     int cmd;

--- a/modules/ppp_mod.h
+++ b/modules/ppp_mod.h
@@ -143,10 +143,10 @@ typedef int minor_t;
  */
 #ifdef SVR4
 #define MOD_OPEN_DECL(name)	\
-static int name __P((queue_t *, dev_t *, int, int, cred_t *))
+static int name(queue_t *, dev_t *, int, int, cred_t *)
 
 #define MOD_CLOSE_DECL(name)	\
-static int name __P((queue_t *, int, cred_t *))
+static int name(queue_t *, int, cred_t *)
 
 #define MOD_OPEN(name)				\
 static int name(q, devp, flag, sflag, credp)	\
@@ -168,10 +168,10 @@ static int name(q, flag, credp)	\
 
 #else	/* not SVR4 */
 #define MOD_OPEN_DECL(name)	\
-static int name __P((queue_t *, int, int, int))
+static int name(queue_t *, int, int, int)
 
 #define MOD_CLOSE_DECL(name)	\
-static int name __P((queue_t *, int))
+static int name(queue_t *, int)
 
 #define MOD_OPEN(name)		\
 static int name(q, dev, flag, sflag)	\

--- a/pppd/auth.c
+++ b/pppd/auth.c
@@ -168,43 +168,43 @@ static int passwd_from_file;
 static bool default_auth;
 
 /* Hook to enable a plugin to control the idle time limit */
-int (*idle_time_hook) __P((struct ppp_idle *)) = NULL;
+int (*idle_time_hook)(struct ppp_idle *) = NULL;
 
 /* Hook for a plugin to say whether we can possibly authenticate any peer */
-int (*pap_check_hook) __P((void)) = NULL;
+int (*pap_check_hook)(void) = NULL;
 
 /* Hook for a plugin to check the PAP user and password */
-int (*pap_auth_hook) __P((char *user, char *passwd, char **msgp,
+int (*pap_auth_hook)(char *user, char *passwd, char **msgp,
 			  struct wordlist **paddrs,
-			  struct wordlist **popts)) = NULL;
+			  struct wordlist **popts) = NULL;
 
 /* Hook for a plugin to know about the PAP user logout */
-void (*pap_logout_hook) __P((void)) = NULL;
+void (*pap_logout_hook)(void) = NULL;
 
 /* Hook for a plugin to get the PAP password for authenticating us */
-int (*pap_passwd_hook) __P((char *user, char *passwd)) = NULL;
+int (*pap_passwd_hook)(char *user, char *passwd) = NULL;
 
 /* Hook for a plugin to say if we can possibly authenticate a peer using CHAP */
-int (*chap_check_hook) __P((void)) = NULL;
+int (*chap_check_hook)(void) = NULL;
 
 /* Hook for a plugin to get the CHAP password for authenticating us */
-int (*chap_passwd_hook) __P((char *user, char *passwd)) = NULL;
+int (*chap_passwd_hook)(char *user, char *passwd) = NULL;
 
 #ifdef USE_EAPTLS
 /* Hook for a plugin to get the EAP-TLS password for authenticating us */
-int (*eaptls_passwd_hook) __P((char *user, char *passwd)) = NULL;
+int (*eaptls_passwd_hook)(char *user, char *passwd) = NULL;
 #endif
 
 /* Hook for a plugin to say whether it is OK if the peer
    refuses to authenticate. */
-int (*null_auth_hook) __P((struct wordlist **paddrs,
-			   struct wordlist **popts)) = NULL;
+int (*null_auth_hook)(struct wordlist **paddrs,
+			   struct wordlist **popts) = NULL;
 
-int (*allowed_address_hook) __P((u_int32_t addr)) = NULL;
+int (*allowed_address_hook)(u_int32_t addr) = NULL;
 
 #ifdef HAVE_MULTILINK
 /* Hook for plugin to hear when an interface joins a multilink bundle */
-void (*multilink_join_hook) __P((void)) = NULL;
+void (*multilink_join_hook)(void) = NULL;
 #endif
 
 /* A notifier for when the peer has authenticated itself,
@@ -263,50 +263,50 @@ bool need_peer_eap = 0;			/* Require peer to authenticate us */
 
 static char *uafname;		/* name of most recent +ua file */
 
-extern char *crypt __P((const char *, const char *));
+extern char *crypt(const char *, const char *);
 
 /* Prototypes for procedures local to this file. */
 
-static void network_phase __P((int));
-static void check_idle __P((void *));
-static void connect_time_expired __P((void *));
-static int  null_login __P((int));
-static int  get_pap_passwd __P((char *));
-static int  have_pap_secret __P((int *));
-static int  have_chap_secret __P((char *, char *, int, int *));
-static int  have_srp_secret __P((char *client, char *server, int need_ip,
-    int *lacks_ipp));
+static void network_phase(int);
+static void check_idle(void *);
+static void connect_time_expired(void *);
+static int  null_login(int);
+static int  get_pap_passwd(char *);
+static int  have_pap_secret(int *);
+static int  have_chap_secret(char *, char *, int, int *);
+static int  have_srp_secret(char *client, char *server, int need_ip,
+    int *lacks_ipp);
 
 #ifdef USE_EAPTLS
 static int  have_eaptls_secret_server
-__P((char *client, char *server, int need_ip, int *lacks_ipp));
-static int  have_eaptls_secret_client __P((char *client, char *server));
-static int  scan_authfile_eaptls __P((FILE * f, char *client, char *server,
+(char *client, char *server, int need_ip, int *lacks_ipp);
+static int  have_eaptls_secret_client(char *client, char *server);
+static int  scan_authfile_eaptls(FILE * f, char *client, char *server,
 			       char *cli_cert, char *serv_cert,
 			       char *ca_cert, char *pk,
 			       struct wordlist ** addrs,
 			       struct wordlist ** opts,
-			       char *filename, int flags));
+			       char *filename, int flags);
 #endif
 
-static int  ip_addr_check __P((u_int32_t, struct permitted_ip *));
-static int  scan_authfile __P((FILE *, char *, char *, char *,
+static int  ip_addr_check(u_int32_t, struct permitted_ip *);
+static int  scan_authfile(FILE *, char *, char *, char *,
 			       struct wordlist **, struct wordlist **,
-			       char *, int));
-static void free_wordlist __P((struct wordlist *));
-static void auth_script __P((char *));
-static void auth_script_done __P((void *));
-static void set_allowed_addrs __P((int, struct wordlist *, struct wordlist *));
-static int  some_ip_ok __P((struct wordlist *));
-static int  setupapfile __P((char **));
-static int  privgroup __P((char **));
-static int  set_noauth_addr __P((char **));
-static int  set_permitted_number __P((char **));
-static void check_access __P((FILE *, char *));
-static int  wordlist_count __P((struct wordlist *));
+			       char *, int);
+static void free_wordlist(struct wordlist *);
+static void auth_script(char *);
+static void auth_script_done(void *);
+static void set_allowed_addrs(int, struct wordlist *, struct wordlist *);
+static int  some_ip_ok(struct wordlist *);
+static int  setupapfile(char **);
+static int  privgroup(char **);
+static int  set_noauth_addr(char **);
+static int  set_permitted_number(char **);
+static void check_access(FILE *, char *);
+static int  wordlist_count(struct wordlist *);
 
 #ifdef MAXOCTETS
-static void check_maxoctets __P((void *));
+static void check_maxoctets(void *);
 #endif
 
 /*

--- a/pppd/cbcp.c
+++ b/pppd/cbcp.c
@@ -49,7 +49,7 @@
 /*
  * Options.
  */
-static int setcbcp __P((char **));
+static int setcbcp(char **);
 
 static option_t cbcp_option_list[] = {
     { "callback", o_special, (void *)setcbcp,
@@ -60,14 +60,14 @@ static option_t cbcp_option_list[] = {
 /*
  * Protocol entry points.
  */
-static void cbcp_init      __P((int unit));
-static void cbcp_open      __P((int unit));
-static void cbcp_lowerup   __P((int unit));
-static void cbcp_input     __P((int unit, u_char *pkt, int len));
-static void cbcp_protrej   __P((int unit));
-static int  cbcp_printpkt  __P((u_char *pkt, int len,
-				void (*printer) __P((void *, char *, ...)),
-				void *arg));
+static void cbcp_init     (int unit);
+static void cbcp_open     (int unit);
+static void cbcp_lowerup  (int unit);
+static void cbcp_input    (int unit, u_char *pkt, int len);
+static void cbcp_protrej  (int unit);
+static int  cbcp_printpkt (u_char *pkt, int len,
+				void (*printer)(void *, char *, ...),
+				void *arg);
 
 struct protent cbcp_protent = {
     PPP_CBCP,
@@ -93,11 +93,11 @@ cbcp_state cbcp[NUM_PPP];
 
 /* internal prototypes */
 
-static void cbcp_recvreq __P((cbcp_state *us, u_char *pckt, int len));
-static void cbcp_resp __P((cbcp_state *us));
-static void cbcp_up __P((cbcp_state *us));
-static void cbcp_recvack __P((cbcp_state *us, u_char *pckt, int len));
-static void cbcp_send __P((cbcp_state *us, int code, u_char *buf, int len));
+static void cbcp_recvreq(cbcp_state *us, u_char *pckt, int len);
+static void cbcp_resp(cbcp_state *us);
+static void cbcp_up(cbcp_state *us);
+static void cbcp_recvack(cbcp_state *us, u_char *pckt, int len);
+static void cbcp_send(cbcp_state *us, int code, u_char *buf, int len);
 
 /* option processing */
 static int
@@ -226,7 +226,7 @@ static int
 cbcp_printpkt(p, plen, printer, arg)
     u_char *p;
     int plen;
-    void (*printer) __P((void *, char *, ...));
+    void (*printer)(void *, char *, ...);
     void *arg;
 {
     int code, opt, id, len, olen, delay;

--- a/pppd/ccp.c
+++ b/pppd/ccp.c
@@ -56,8 +56,8 @@
 /*
  * Command-line options.
  */
-static int setbsdcomp __P((char **));
-static int setdeflate __P((char **));
+static int setbsdcomp(char **);
+static int setdeflate(char **);
 static char bsd_value[8];
 static char deflate_value[8];
 
@@ -163,17 +163,17 @@ static option_t ccp_option_list[] = {
 /*
  * Protocol entry points from main code.
  */
-static void ccp_init __P((int unit));
-static void ccp_open __P((int unit));
-static void ccp_close __P((int unit, char *));
-static void ccp_lowerup __P((int unit));
-static void ccp_lowerdown __P((int));
-static void ccp_input __P((int unit, u_char *pkt, int len));
-static void ccp_protrej __P((int unit));
-static int  ccp_printpkt __P((u_char *pkt, int len,
-			      void (*printer) __P((void *, char *, ...)),
-			      void *arg));
-static void ccp_datainput __P((int unit, u_char *pkt, int len));
+static void ccp_init(int unit);
+static void ccp_open(int unit);
+static void ccp_close(int unit, char *);
+static void ccp_lowerup(int unit);
+static void ccp_lowerdown(int);
+static void ccp_input(int unit, u_char *pkt, int len);
+static void ccp_protrej(int unit);
+static int  ccp_printpkt(u_char *pkt, int len,
+			      void (*printer)(void *, char *, ...),
+			      void *arg);
+static void ccp_datainput(int unit, u_char *pkt, int len);
 
 struct protent ccp_protent = {
     PPP_CCP,
@@ -204,18 +204,18 @@ ccp_options ccp_hisoptions[NUM_PPP];	/* what we agreed to do */
 /*
  * Callbacks for fsm code.
  */
-static void ccp_resetci __P((fsm *));
-static int  ccp_cilen __P((fsm *));
-static void ccp_addci __P((fsm *, u_char *, int *));
-static int  ccp_ackci __P((fsm *, u_char *, int));
-static int  ccp_nakci __P((fsm *, u_char *, int, int));
-static int  ccp_rejci __P((fsm *, u_char *, int));
-static int  ccp_reqci __P((fsm *, u_char *, int *, int));
-static void ccp_up __P((fsm *));
-static void ccp_down __P((fsm *));
-static int  ccp_extcode __P((fsm *, int, int, u_char *, int));
-static void ccp_rack_timeout __P((void *));
-static char *method_name __P((ccp_options *, ccp_options *));
+static void ccp_resetci(fsm *);
+static int  ccp_cilen(fsm *);
+static void ccp_addci(fsm *, u_char *, int *);
+static int  ccp_ackci(fsm *, u_char *, int);
+static int  ccp_nakci(fsm *, u_char *, int, int);
+static int  ccp_rejci(fsm *, u_char *, int);
+static int  ccp_reqci(fsm *, u_char *, int *, int);
+static void ccp_up(fsm *);
+static void ccp_down(fsm *);
+static int  ccp_extcode(fsm *, int, int, u_char *, int);
+static void ccp_rack_timeout(void *);
+static char *method_name(ccp_options *, ccp_options *);
 
 static fsm_callbacks ccp_callbacks = {
     ccp_resetci,
@@ -1507,7 +1507,7 @@ static int
 ccp_printpkt(p, plen, printer, arg)
     u_char *p;
     int plen;
-    void (*printer) __P((void *, char *, ...));
+    void (*printer)(void *, char *, ...);
     void *arg;
 {
     u_char *p0, *optend;

--- a/pppd/chap-new.c
+++ b/pppd/chap-new.c
@@ -129,7 +129,7 @@ static void chap_handle_status(struct chap_client_state *cs, int code, int id,
 static void chap_protrej(int unit);
 static void chap_input(int unit, unsigned char *pkt, int pktlen);
 static int chap_print_pkt(unsigned char *p, int plen,
-		void (*printer) __P((void *, char *, ...)), void *arg);
+		void (*printer)(void *, char *, ...), void *arg);
 
 /* List of digest types that we know about */
 static struct chap_digest_type *chap_digests;
@@ -584,7 +584,7 @@ static char *chap_code_names[] = {
 
 static int
 chap_print_pkt(unsigned char *p, int plen,
-	       void (*printer) __P((void *, char *, ...)), void *arg)
+	       void (*printer)(void *, char *, ...), void *arg)
 {
 	int code, id, len;
 	int clen, nlen;

--- a/pppd/chap_ms.c
+++ b/pppd/chap_ms.c
@@ -96,22 +96,22 @@
 
 
 
-static void	ascii2unicode __P((char[], int, u_char[]));
-static void	NTPasswordHash __P((u_char *, int, u_char[MD4_SIGNATURE_SIZE]));
-static void	ChallengeResponse __P((u_char *, u_char *, u_char[24]));
-static void	ChapMS_NT __P((u_char *, char *, int, u_char[24]));
-static void	ChapMS2_NT __P((u_char *, u_char[16], char *, char *, int,
-				u_char[24]));
+static void	ascii2unicode(char[], int, u_char[]);
+static void	NTPasswordHash(u_char *, int, u_char[MD4_SIGNATURE_SIZE]);
+static void	ChallengeResponse(u_char *, u_char *, u_char[24]);
+static void	ChapMS_NT(u_char *, char *, int, u_char[24]);
+static void	ChapMS2_NT(u_char *, u_char[16], char *, char *, int,
+				u_char[24]);
 static void	GenerateAuthenticatorResponsePlain
-			__P((char*, int, u_char[24], u_char[16], u_char *,
-			     char *, u_char[41]));
+			(char*, int, u_char[24], u_char[16], u_char *,
+			     char *, u_char[41]);
 #ifdef MSLANMAN
-static void	ChapMS_LANMan __P((u_char *, char *, int, u_char *));
+static void	ChapMS_LANMan(u_char *, char *, int, u_char *);
 #endif
 
 #ifdef MPPE
-static void	Set_Start_Key __P((u_char *, char *, int));
-static void	SetMasterKeys __P((char *, int, u_char[24], int));
+static void	Set_Start_Key(u_char *, char *, int);
+static void	SetMasterKeys(char *, int, u_char[24], int);
 #endif
 
 #ifdef MSLANMAN

--- a/pppd/chap_ms.h
+++ b/pppd/chap_ms.h
@@ -87,16 +87,16 @@ extern void set_mppe_enc_types(int, int);
 #define MS_CHAP2_AUTHENTICATEE 0
 #define MS_CHAP2_AUTHENTICATOR 1
 
-void ChapMS __P((u_char *, char *, int, u_char *));
-void ChapMS2 __P((u_char *, u_char *, char *, char *, int,
-		  u_char *, u_char[MS_AUTH_RESPONSE_LENGTH+1], int));
+void ChapMS(u_char *, char *, int, u_char *);
+void ChapMS2(u_char *, u_char *, char *, char *, int,
+		  u_char *, u_char[MS_AUTH_RESPONSE_LENGTH+1], int);
 #ifdef MPPE
-void mppe_set_keys __P((u_char *, u_char[MD4_SIGNATURE_SIZE]));
+void mppe_set_keys(u_char *, u_char[MD4_SIGNATURE_SIZE]);
 void mppe_set_keys2(u_char PasswordHashHash[MD4_SIGNATURE_SIZE],
 		    u_char NTResponse[24], int IsServer);
 #endif
 
-void	ChallengeHash __P((u_char[16], u_char *, char *, u_char[8]));
+void	ChallengeHash(u_char[16], u_char *, char *, u_char[8]);
 
 void GenerateAuthenticatorResponse(u_char PasswordHashHash[MD4_SIGNATURE_SIZE],
 			u_char NTResponse[24], u_char PeerChallenge[16],

--- a/pppd/demand.c
+++ b/pppd/demand.c
@@ -69,7 +69,7 @@ struct packet {
 struct packet *pend_q;
 struct packet *pend_qtail;
 
-static int active_packet __P((unsigned char *, int));
+static int active_packet(unsigned char *, int);
 
 /*
  * demand_conf - configure the interface for doing dial-on-demand.

--- a/pppd/eap.c
+++ b/pppd/eap.c
@@ -118,13 +118,13 @@ static option_t eap_option_list[] = {
 /*
  * Protocol entry points.
  */
-static void eap_init __P((int unit));
-static void eap_input __P((int unit, u_char *inp, int inlen));
-static void eap_protrej __P((int unit));
-static void eap_lowerup __P((int unit));
-static void eap_lowerdown __P((int unit));
-static int  eap_printpkt __P((u_char *inp, int inlen,
-    void (*)(void *arg, char *fmt, ...), void *arg));
+static void eap_init(int unit);
+static void eap_input(int unit, u_char *inp, int inlen);
+static void eap_protrej(int unit);
+static void eap_lowerup(int unit);
+static void eap_lowerdown(int unit);
+static int  eap_printpkt(u_char *inp, int inlen,
+    void (*)(void *arg, char *fmt, ...), void *arg);
 
 struct protent eap_protent = {
 	PPP_EAP,		/* protocol number */
@@ -185,7 +185,7 @@ static const u_char wkmodulus[] = {
 };
 
 /* Local forward declarations. */
-static void eap_server_timeout __P((void *arg));
+static void eap_server_timeout(void *arg);
 
 /*
  * Convert EAP state code to printable string for debug.
@@ -2580,7 +2580,7 @@ static int
 eap_printpkt(inp, inlen, printer, arg)
 u_char *inp;
 int inlen;
-void (*printer) __P((void *, char *, ...));
+void (*printer)(void *, char *, ...);
 void *arg;
 {
 	int code, id, len, rtype, vallen;

--- a/pppd/eap.h
+++ b/pppd/eap.h
@@ -175,8 +175,8 @@ typedef struct eap_state {
 
 extern eap_state eap_states[];
 
-void eap_authwithpeer __P((int unit, char *localname));
-void eap_authpeer __P((int unit, char *localname));
+void eap_authwithpeer(int unit, char *localname);
+void eap_authpeer(int unit, char *localname);
 
 extern struct protent eap_protent;
 

--- a/pppd/ecp.c
+++ b/pppd/ecp.c
@@ -78,20 +78,20 @@ static option_t ecp_option_list[] = {
 /*
  * Protocol entry points from main code.
  */
-static void ecp_init __P((int unit));
+static void ecp_init(int unit);
 /*
-static void ecp_open __P((int unit));
-static void ecp_close __P((int unit, char *));
-static void ecp_lowerup __P((int unit));
-static void ecp_lowerdown __P((int));
-static void ecp_input __P((int unit, u_char *pkt, int len));
-static void ecp_protrej __P((int unit));
+static void ecp_open(int unit);
+static void ecp_close(int unit, char *);
+static void ecp_lowerup(int unit);
+static void ecp_lowerdown(int);
+static void ecp_input(int unit, u_char *pkt, int len);
+static void ecp_protrej(int unit);
 */
-static int  ecp_printpkt __P((u_char *pkt, int len,
-			      void (*printer) __P((void *, char *, ...)),
-			      void *arg));
+static int  ecp_printpkt(u_char *pkt, int len,
+			      void (*printer)(void *, char *, ...),
+			      void *arg);
 /*
-static void ecp_datainput __P((int unit, u_char *pkt, int len));
+static void ecp_datainput(int unit, u_char *pkt, int len);
 */
 
 struct protent ecp_protent = {
@@ -164,7 +164,7 @@ static int
 ecp_printpkt(p, plen, printer, arg)
     u_char *p;
     int plen;
-    void (*printer) __P((void *, char *, ...));
+    void (*printer)(void *, char *, ...);
     void *arg;
 {
     return 0;

--- a/pppd/eui64.h
+++ b/pppd/eui64.h
@@ -108,7 +108,7 @@ typedef union
 				} while (0)
 #define eui64_setlo32(e, l)	eui64_set32(e, l)
 
-char *eui64_ntoa __P((eui64_t));	/* Returns ascii representation of id */
+char *eui64_ntoa(eui64_t);	/* Returns ascii representation of id */
 
 #endif /* __EUI64_H__ */
 

--- a/pppd/fsm.c
+++ b/pppd/fsm.c
@@ -56,14 +56,14 @@
 #include "fsm.h"
 
 
-static void fsm_timeout __P((void *));
-static void fsm_rconfreq __P((fsm *, int, u_char *, int));
-static void fsm_rconfack __P((fsm *, int, u_char *, int));
-static void fsm_rconfnakrej __P((fsm *, int, int, u_char *, int));
-static void fsm_rtermreq __P((fsm *, int, u_char *, int));
-static void fsm_rtermack __P((fsm *));
-static void fsm_rcoderej __P((fsm *, u_char *, int));
-static void fsm_sconfreq __P((fsm *, int));
+static void fsm_timeout(void *);
+static void fsm_rconfreq(fsm *, int, u_char *, int);
+static void fsm_rconfack(fsm *, int, u_char *, int);
+static void fsm_rconfnakrej(fsm *, int, int, u_char *, int);
+static void fsm_rtermreq(fsm *, int, u_char *, int);
+static void fsm_rtermack(fsm *);
+static void fsm_rcoderej(fsm *, u_char *, int);
+static void fsm_sconfreq(fsm *, int);
 
 #define PROTO_NAME(f)	((f)->callbacks->proto_name)
 

--- a/pppd/fsm.h
+++ b/pppd/fsm.h
@@ -86,33 +86,33 @@ typedef struct fsm {
 
 typedef struct fsm_callbacks {
     void (*resetci)		/* Reset our Configuration Information */
-		__P((fsm *));
+		(fsm *);
     int  (*cilen)		/* Length of our Configuration Information */
-		__P((fsm *));
+		(fsm *);
     void (*addci) 		/* Add our Configuration Information */
-		__P((fsm *, u_char *, int *));
+		(fsm *, u_char *, int *);
     int  (*ackci)		/* ACK our Configuration Information */
-		__P((fsm *, u_char *, int));
+		(fsm *, u_char *, int);
     int  (*nakci)		/* NAK our Configuration Information */
-		__P((fsm *, u_char *, int, int));
+		(fsm *, u_char *, int, int);
     int  (*rejci)		/* Reject our Configuration Information */
-		__P((fsm *, u_char *, int));
+		(fsm *, u_char *, int);
     int  (*reqci)		/* Request peer's Configuration Information */
-		__P((fsm *, u_char *, int *, int));
+		(fsm *, u_char *, int *, int);
     void (*up)			/* Called when fsm reaches OPENED state */
-		__P((fsm *));
+		(fsm *);
     void (*down)		/* Called when fsm leaves OPENED state */
-		__P((fsm *));
+		(fsm *);
     void (*starting)		/* Called when we want the lower layer */
-		__P((fsm *));
+		(fsm *);
     void (*finished)		/* Called when we don't want the lower layer */
-		__P((fsm *));
+		(fsm *);
     void (*protreject)		/* Called when Protocol-Reject received */
-		__P((int));
+		(int);
     void (*retransmit)		/* Retransmission is necessary */
-		__P((fsm *));
+		(fsm *);
     int  (*extcode)		/* Called when unknown code received */
-		__P((fsm *, int, int, u_char *, int));
+		(fsm *, int, int, u_char *, int);
     char *proto_name;		/* String name for protocol (for messages) */
 } fsm_callbacks;
 
@@ -152,14 +152,14 @@ typedef struct fsm_callbacks {
 /*
  * Prototypes
  */
-void fsm_init __P((fsm *));
-void fsm_lowerup __P((fsm *));
-void fsm_lowerdown __P((fsm *));
-void fsm_open __P((fsm *));
-void fsm_close __P((fsm *, char *));
-void fsm_input __P((fsm *, u_char *, int));
-void fsm_protreject __P((fsm *));
-void fsm_sdata __P((fsm *, int, int, u_char *, int));
+void fsm_init(fsm *);
+void fsm_lowerup(fsm *);
+void fsm_lowerdown(fsm *);
+void fsm_open(fsm *);
+void fsm_close(fsm *, char *);
+void fsm_input(fsm *, u_char *, int);
+void fsm_protreject(fsm *);
+void fsm_sdata(fsm *, int, int, u_char *, int);
 
 
 /*

--- a/pppd/ipcp.c
+++ b/pppd/ipcp.c
@@ -74,13 +74,13 @@ bool	disable_defaultip = 0;	/* Don't use hostname for default IP adrs */
 bool	noremoteip = 0;		/* Let him have no IP address */
 
 /* Hook for a plugin to know when IP protocol has come up */
-void (*ip_up_hook) __P((void)) = NULL;
+void (*ip_up_hook)(void) = NULL;
 
 /* Hook for a plugin to know when IP protocol has come down */
-void (*ip_down_hook) __P((void)) = NULL;
+void (*ip_down_hook)(void) = NULL;
 
 /* Hook for a plugin to choose the remote IP address */
-void (*ip_choose_hook) __P((u_int32_t *)) = NULL;
+void (*ip_choose_hook)(u_int32_t *) = NULL;
 
 /* Notifiers for when IPCP goes up and down */
 struct notifier *ip_up_notifier = NULL;
@@ -99,16 +99,16 @@ static char netmask_str[20];		/* string form of netmask value */
 /*
  * Callbacks for fsm code.  (CI = Configuration Information)
  */
-static void ipcp_resetci __P((fsm *));	/* Reset our CI */
-static int  ipcp_cilen __P((fsm *));	        /* Return length of our CI */
-static void ipcp_addci __P((fsm *, u_char *, int *)); /* Add our CI */
-static int  ipcp_ackci __P((fsm *, u_char *, int));	/* Peer ack'd our CI */
-static int  ipcp_nakci __P((fsm *, u_char *, int, int));/* Peer nak'd our CI */
-static int  ipcp_rejci __P((fsm *, u_char *, int));	/* Peer rej'd our CI */
-static int  ipcp_reqci __P((fsm *, u_char *, int *, int)); /* Rcv CI */
-static void ipcp_up __P((fsm *));		/* We're UP */
-static void ipcp_down __P((fsm *));		/* We're DOWN */
-static void ipcp_finished __P((fsm *));	/* Don't need lower layer */
+static void ipcp_resetci(fsm *);	/* Reset our CI */
+static int  ipcp_cilen(fsm *);	        /* Return length of our CI */
+static void ipcp_addci(fsm *, u_char *, int *); /* Add our CI */
+static int  ipcp_ackci(fsm *, u_char *, int);	/* Peer ack'd our CI */
+static int  ipcp_nakci(fsm *, u_char *, int, int);/* Peer nak'd our CI */
+static int  ipcp_rejci(fsm *, u_char *, int);	/* Peer rej'd our CI */
+static int  ipcp_reqci(fsm *, u_char *, int *, int); /* Rcv CI */
+static void ipcp_up(fsm *);		/* We're UP */
+static void ipcp_down(fsm *);		/* We're DOWN */
+static void ipcp_finished(fsm *);	/* Don't need lower layer */
 
 fsm ipcp_fsm[NUM_PPP];		/* IPCP fsm structure */
 
@@ -133,12 +133,12 @@ static fsm_callbacks ipcp_callbacks = { /* IPCP callback routines */
 /*
  * Command-line options.
  */
-static int setvjslots __P((char **));
-static int setdnsaddr __P((char **));
-static int setwinsaddr __P((char **));
-static int setnetmask __P((char **));
-int setipaddr __P((char *, char **, int));
-static void printipaddr __P((option_t *, void (*)(void *, char *,...),void *));
+static int setvjslots(char **);
+static int setdnsaddr(char **);
+static int setwinsaddr(char **);
+static int setnetmask(char **);
+int setipaddr(char *, char **, int);
+static void printipaddr(option_t *, void (*)(void *, char *,...),void *);
 
 static option_t ipcp_option_list[] = {
     { "noip", o_bool, &ipcp_protent.enabled_flag,
@@ -236,19 +236,19 @@ static option_t ipcp_option_list[] = {
 /*
  * Protocol entry points from main code.
  */
-static void ipcp_init __P((int));
-static void ipcp_open __P((int));
-static void ipcp_close __P((int, char *));
-static void ipcp_lowerup __P((int));
-static void ipcp_lowerdown __P((int));
-static void ipcp_input __P((int, u_char *, int));
-static void ipcp_protrej __P((int));
-static int  ipcp_printpkt __P((u_char *, int,
-			       void (*) __P((void *, char *, ...)), void *));
-static void ip_check_options __P((void));
-static int  ip_demand_conf __P((int));
-static int  ip_active_pkt __P((u_char *, int));
-static void create_resolv __P((u_int32_t, u_int32_t));
+static void ipcp_init(int);
+static void ipcp_open(int);
+static void ipcp_close(int, char *);
+static void ipcp_lowerup(int);
+static void ipcp_lowerdown(int);
+static void ipcp_input(int, u_char *, int);
+static void ipcp_protrej(int);
+static int  ipcp_printpkt(u_char *, int,
+			       void (*)(void *, char *, ...), void *);
+static void ip_check_options(void);
+static int  ip_demand_conf(int);
+static int  ip_active_pkt(u_char *, int);
+static void create_resolv(u_int32_t, u_int32_t);
 
 struct protent ipcp_protent = {
     PPP_IPCP,
@@ -270,9 +270,9 @@ struct protent ipcp_protent = {
     ip_active_pkt
 };
 
-static void ipcp_clear_addrs __P((int, u_int32_t, u_int32_t));
-static void ipcp_script __P((char *, int));	/* Run an up/down script */
-static void ipcp_script_done __P((void *));
+static void ipcp_clear_addrs(int, u_int32_t, u_int32_t);
+static void ipcp_script(char *, int);	/* Run an up/down script */
+static void ipcp_script_done(void *);
 
 /*
  * Lengths of configuration options.
@@ -481,7 +481,7 @@ setipaddr(arg, argv, doit)
 static void
 printipaddr(opt, printer, arg)
     option_t *opt;
-    void (*printer) __P((void *, char *, ...));
+    void (*printer)(void *, char *, ...);
     void *arg;
 {
 	ipcp_options *wo = &ipcp_wantoptions[0];
@@ -2144,7 +2144,7 @@ static int
 ipcp_printpkt(p, plen, printer, arg)
     u_char *p;
     int plen;
-    void (*printer) __P((void *, char *, ...));
+    void (*printer)(void *, char *, ...);
     void *arg;
 {
     int code, id, len, olen;

--- a/pppd/ipcp.h
+++ b/pppd/ipcp.h
@@ -91,6 +91,6 @@ extern ipcp_options ipcp_gotoptions[];
 extern ipcp_options ipcp_allowoptions[];
 extern ipcp_options ipcp_hisoptions[];
 
-char *ip_ntoa __P((u_int32_t));
+char *ip_ntoa(u_int32_t);
 
 extern struct protent ipcp_protent;

--- a/pppd/ipv6cp.c
+++ b/pppd/ipv6cp.c
@@ -181,10 +181,10 @@ static int default_route_set[NUM_PPP];		/* Have set up a default route */
 static int ipv6cp_is_up;
 
 /* Hook for a plugin to know when IPv6 protocol has come up */
-void (*ipv6_up_hook) __P((void)) = NULL;
+void (*ipv6_up_hook)(void) = NULL;
 
 /* Hook for a plugin to know when IPv6 protocol has come down */
-void (*ipv6_down_hook) __P((void)) = NULL;
+void (*ipv6_down_hook)(void) = NULL;
 
 /* Notifiers for when IPCPv6 goes up and down */
 struct notifier *ipv6_up_notifier = NULL;
@@ -193,16 +193,16 @@ struct notifier *ipv6_down_notifier = NULL;
 /*
  * Callbacks for fsm code.  (CI = Configuration Information)
  */
-static void ipv6cp_resetci __P((fsm *));	/* Reset our CI */
-static int  ipv6cp_cilen __P((fsm *));	        /* Return length of our CI */
-static void ipv6cp_addci __P((fsm *, u_char *, int *)); /* Add our CI */
-static int  ipv6cp_ackci __P((fsm *, u_char *, int));	/* Peer ack'd our CI */
-static int  ipv6cp_nakci __P((fsm *, u_char *, int, int));/* Peer nak'd our CI */
-static int  ipv6cp_rejci __P((fsm *, u_char *, int));	/* Peer rej'd our CI */
-static int  ipv6cp_reqci __P((fsm *, u_char *, int *, int)); /* Rcv CI */
-static void ipv6cp_up __P((fsm *));		/* We're UP */
-static void ipv6cp_down __P((fsm *));		/* We're DOWN */
-static void ipv6cp_finished __P((fsm *));	/* Don't need lower layer */
+static void ipv6cp_resetci(fsm *);	/* Reset our CI */
+static int  ipv6cp_cilen(fsm *);	        /* Return length of our CI */
+static void ipv6cp_addci(fsm *, u_char *, int *); /* Add our CI */
+static int  ipv6cp_ackci(fsm *, u_char *, int);	/* Peer ack'd our CI */
+static int  ipv6cp_nakci(fsm *, u_char *, int, int);/* Peer nak'd our CI */
+static int  ipv6cp_rejci(fsm *, u_char *, int);	/* Peer rej'd our CI */
+static int  ipv6cp_reqci(fsm *, u_char *, int *, int); /* Rcv CI */
+static void ipv6cp_up(fsm *);		/* We're UP */
+static void ipv6cp_down(fsm *);		/* We're DOWN */
+static void ipv6cp_finished(fsm *);	/* Don't need lower layer */
 
 fsm ipv6cp_fsm[NUM_PPP];		/* IPV6CP fsm structure */
 
@@ -227,9 +227,9 @@ static fsm_callbacks ipv6cp_callbacks = { /* IPV6CP callback routines */
 /*
  * Command-line options.
  */
-static int setifaceid __P((char **arg));
-static void printifaceid __P((option_t *,
-			      void (*)(void *, char *, ...), void *));
+static int setifaceid(char **arg);
+static void printifaceid(option_t *,
+			      void (*)(void *, char *, ...), void *);
 
 static option_t ipv6cp_option_list[] = {
     { "ipv6", o_special, (void *)setifaceid,
@@ -279,18 +279,18 @@ static option_t ipv6cp_option_list[] = {
 /*
  * Protocol entry points from main code.
  */
-static void ipv6cp_init __P((int));
-static void ipv6cp_open __P((int));
-static void ipv6cp_close __P((int, char *));
-static void ipv6cp_lowerup __P((int));
-static void ipv6cp_lowerdown __P((int));
-static void ipv6cp_input __P((int, u_char *, int));
-static void ipv6cp_protrej __P((int));
-static int  ipv6cp_printpkt __P((u_char *, int,
-			       void (*) __P((void *, char *, ...)), void *));
-static void ipv6_check_options __P((void));
-static int  ipv6_demand_conf __P((int));
-static int  ipv6_active_pkt __P((u_char *, int));
+static void ipv6cp_init(int);
+static void ipv6cp_open(int);
+static void ipv6cp_close(int, char *);
+static void ipv6cp_lowerup(int);
+static void ipv6cp_lowerdown(int);
+static void ipv6cp_input(int, u_char *, int);
+static void ipv6cp_protrej(int);
+static int  ipv6cp_printpkt(u_char *, int,
+			       void (*)(void *, char *, ...), void *);
+static void ipv6_check_options(void);
+static int  ipv6_demand_conf(int);
+static int  ipv6_active_pkt(u_char *, int);
 
 struct protent ipv6cp_protent = {
     PPP_IPV6CP,
@@ -312,9 +312,9 @@ struct protent ipv6cp_protent = {
     ipv6_active_pkt
 };
 
-static void ipv6cp_clear_addrs __P((int, eui64_t, eui64_t));
-static void ipv6cp_script __P((char *));
-static void ipv6cp_script_done __P((void *));
+static void ipv6cp_clear_addrs(int, eui64_t, eui64_t);
+static void ipv6cp_script(char *);
+static void ipv6cp_script_done(void *);
 
 /*
  * Lengths of configuration options.
@@ -400,7 +400,7 @@ char *llv6_ntoa(eui64_t ifaceid);
 static void
 printifaceid(opt, printer, arg)
     option_t *opt;
-    void (*printer) __P((void *, char *, ...));
+    void (*printer)(void *, char *, ...);
     void *arg;
 {
 	ipv6cp_options *wo = &ipv6cp_wantoptions[0];
@@ -1448,7 +1448,7 @@ static int
 ipv6cp_printpkt(p, plen, printer, arg)
     u_char *p;
     int plen;
-    void (*printer) __P((void *, char *, ...));
+    void (*printer)(void *, char *, ...);
     void *arg;
 {
     int code, id, len, olen;

--- a/pppd/ipxcp.c
+++ b/pppd/ipxcp.c
@@ -77,17 +77,17 @@ ipxcp_options ipxcp_hisoptions[NUM_PPP];	/* Options that we ack'd */
 /*
  * Callbacks for fsm code.  (CI = Configuration Information)
  */
-static void ipxcp_resetci __P((fsm *));	/* Reset our CI */
-static int  ipxcp_cilen __P((fsm *));		/* Return length of our CI */
-static void ipxcp_addci __P((fsm *, u_char *, int *)); /* Add our CI */
-static int  ipxcp_ackci __P((fsm *, u_char *, int));	/* Peer ack'd our CI */
-static int  ipxcp_nakci __P((fsm *, u_char *, int, int));/* Peer nak'd our CI */
-static int  ipxcp_rejci __P((fsm *, u_char *, int));	/* Peer rej'd our CI */
-static int  ipxcp_reqci __P((fsm *, u_char *, int *, int)); /* Rcv CI */
-static void ipxcp_up __P((fsm *));		/* We're UP */
-static void ipxcp_down __P((fsm *));		/* We're DOWN */
-static void ipxcp_finished __P((fsm *));	/* Don't need lower layer */
-static void ipxcp_script __P((fsm *, char *)); /* Run an up/down script */
+static void ipxcp_resetci(fsm *);	/* Reset our CI */
+static int  ipxcp_cilen(fsm *);		/* Return length of our CI */
+static void ipxcp_addci(fsm *, u_char *, int *); /* Add our CI */
+static int  ipxcp_ackci(fsm *, u_char *, int);	/* Peer ack'd our CI */
+static int  ipxcp_nakci(fsm *, u_char *, int, int);/* Peer nak'd our CI */
+static int  ipxcp_rejci(fsm *, u_char *, int);	/* Peer rej'd our CI */
+static int  ipxcp_reqci(fsm *, u_char *, int *, int); /* Rcv CI */
+static void ipxcp_up(fsm *);		/* We're UP */
+static void ipxcp_down(fsm *);		/* We're DOWN */
+static void ipxcp_finished(fsm *);	/* Don't need lower layer */
+static void ipxcp_script(fsm *, char *); /* Run an up/down script */
 
 fsm ipxcp_fsm[NUM_PPP];		/* IPXCP fsm structure */
 
@@ -112,10 +112,10 @@ static fsm_callbacks ipxcp_callbacks = { /* IPXCP callback routines */
 /*
  * Command-line options.
  */
-static int setipxnode __P((char **));
-static void printipxnode __P((option_t *,
-			      void (*)(void *, char *, ...), void *));
-static int setipxname __P((char **));
+static int setipxnode(char **);
+static void printipxnode(option_t *,
+			      void (*)(void *, char *, ...), void *);
+static int setipxname(char **);
 
 static option_t ipxcp_option_list[] = {
     { "ipx", o_bool, &ipxcp_protent.enabled_flag,
@@ -169,15 +169,15 @@ static option_t ipxcp_option_list[] = {
  * Protocol entry points.
  */
 
-static void ipxcp_init __P((int));
-static void ipxcp_open __P((int));
-static void ipxcp_close __P((int, char *));
-static void ipxcp_lowerup __P((int));
-static void ipxcp_lowerdown __P((int));
-static void ipxcp_input __P((int, u_char *, int));
-static void ipxcp_protrej __P((int));
-static int  ipxcp_printpkt __P((u_char *, int,
-				void (*) __P((void *, char *, ...)), void *));
+static void ipxcp_init(int);
+static void ipxcp_open(int);
+static void ipxcp_close(int, char *);
+static void ipxcp_lowerup(int);
+static void ipxcp_lowerdown(int);
+static void ipxcp_input(int, u_char *, int);
+static void ipxcp_protrej(int);
+static int  ipxcp_printpkt(u_char *, int,
+				void (*)(void *, char *, ...), void *);
 
 struct protent ipxcp_protent = {
     PPP_IPXCP,
@@ -216,7 +216,7 @@ struct protent ipxcp_protent = {
 
 static int ipxcp_is_up;
 
-static char *ipx_ntoa __P((u_int32_t));
+static char *ipx_ntoa(u_int32_t);
 
 /* Used in printing the node number */
 #define NODE(base) base[0], base[1], base[2], base[3], base[4], base[5]
@@ -322,7 +322,7 @@ setipxnode(argv)
 static void
 printipxnode(opt, printer, arg)
     option_t *opt;
-    void (*printer) __P((void *, char *, ...));
+    void (*printer)(void *, char *, ...);
     void *arg;
 {
 	unsigned char *p;
@@ -1472,7 +1472,7 @@ static int
 ipxcp_printpkt(p, plen, printer, arg)
     u_char *p;
     int plen;
-    void (*printer) __P((void *, char *, ...));
+    void (*printer)(void *, char *, ...);
     void *arg;
 {
     int code, id, len, olen;

--- a/pppd/lcp.c
+++ b/pppd/lcp.c
@@ -65,7 +65,7 @@
 /* steal a bit in fsm flags word */
 #define DELAYED_UP	0x100
 
-static void lcp_delayed_up __P((void *));
+static void lcp_delayed_up(void *);
 
 /*
  * LCP-related command-line options.
@@ -76,12 +76,12 @@ bool	lcp_echo_adaptive = 0;	/* request echo only if the link was idle */
 bool	lax_recv = 0;		/* accept control chars in asyncmap */
 bool	noendpoint = 0;		/* don't send/accept endpoint discriminator */
 
-static int noopt __P((char **));
+static int noopt(char **);
 
 #ifdef HAVE_MULTILINK
-static int setendpoint __P((char **));
-static void printendpoint __P((option_t *, void (*)(void *, char *, ...),
-			       void *));
+static int setendpoint(char **);
+static void printendpoint(option_t *, void (*)(void *, char *, ...),
+			       void *);
 #endif /* HAVE_MULTILINK */
 
 static option_t lcp_option_list[] = {
@@ -204,31 +204,31 @@ static u_char nak_buffer[PPP_MRU];	/* where we construct a nak packet */
 /*
  * Callbacks for fsm code.  (CI = Configuration Information)
  */
-static void lcp_resetci __P((fsm *));	/* Reset our CI */
-static int  lcp_cilen __P((fsm *));		/* Return length of our CI */
-static void lcp_addci __P((fsm *, u_char *, int *)); /* Add our CI to pkt */
-static int  lcp_ackci __P((fsm *, u_char *, int)); /* Peer ack'd our CI */
-static int  lcp_nakci __P((fsm *, u_char *, int, int)); /* Peer nak'd our CI */
-static int  lcp_rejci __P((fsm *, u_char *, int)); /* Peer rej'd our CI */
-static int  lcp_reqci __P((fsm *, u_char *, int *, int)); /* Rcv peer CI */
-static void lcp_up __P((fsm *));		/* We're UP */
-static void lcp_down __P((fsm *));		/* We're DOWN */
-static void lcp_starting __P((fsm *));	/* We need lower layer up */
-static void lcp_finished __P((fsm *));	/* We need lower layer down */
-static int  lcp_extcode __P((fsm *, int, int, u_char *, int));
-static void lcp_rprotrej __P((fsm *, u_char *, int));
+static void lcp_resetci(fsm *);	/* Reset our CI */
+static int  lcp_cilen(fsm *);		/* Return length of our CI */
+static void lcp_addci(fsm *, u_char *, int *); /* Add our CI to pkt */
+static int  lcp_ackci(fsm *, u_char *, int); /* Peer ack'd our CI */
+static int  lcp_nakci(fsm *, u_char *, int, int); /* Peer nak'd our CI */
+static int  lcp_rejci(fsm *, u_char *, int); /* Peer rej'd our CI */
+static int  lcp_reqci(fsm *, u_char *, int *, int); /* Rcv peer CI */
+static void lcp_up(fsm *);		/* We're UP */
+static void lcp_down(fsm *);		/* We're DOWN */
+static void lcp_starting(fsm *);	/* We need lower layer up */
+static void lcp_finished(fsm *);	/* We need lower layer down */
+static int  lcp_extcode(fsm *, int, int, u_char *, int);
+static void lcp_rprotrej(fsm *, u_char *, int);
 
 /*
  * routines to send LCP echos to peer
  */
 
-static void lcp_echo_lowerup __P((int));
-static void lcp_echo_lowerdown __P((int));
-static void LcpEchoTimeout __P((void *));
-static void lcp_received_echo_reply __P((fsm *, int, u_char *, int));
-static void LcpSendEchoRequest __P((fsm *));
-static void LcpLinkFailure __P((fsm *));
-static void LcpEchoCheck __P((fsm *));
+static void lcp_echo_lowerup(int);
+static void lcp_echo_lowerdown(int);
+static void LcpEchoTimeout(void *);
+static void lcp_received_echo_reply(fsm *, int, u_char *, int);
+static void LcpSendEchoRequest(fsm *);
+static void LcpLinkFailure(fsm *);
+static void LcpEchoCheck(fsm *);
 
 static fsm_callbacks lcp_callbacks = {	/* LCP callback routines */
     lcp_resetci,		/* Reset our Configuration Information */
@@ -253,11 +253,11 @@ static fsm_callbacks lcp_callbacks = {	/* LCP callback routines */
  * Some of these are called directly.
  */
 
-static void lcp_init __P((int));
-static void lcp_input __P((int, u_char *, int));
-static void lcp_protrej __P((int));
-static int  lcp_printpkt __P((u_char *, int,
-			      void (*) __P((void *, char *, ...)), void *));
+static void lcp_init(int);
+static void lcp_input(int, u_char *, int);
+static void lcp_protrej(int);
+static int  lcp_printpkt(u_char *, int,
+			      void (*)(void *, char *, ...), void *);
 
 struct protent lcp_protent = {
     PPP_LCP,
@@ -324,7 +324,7 @@ setendpoint(argv)
 static void
 printendpoint(opt, printer, arg)
     option_t *opt;
-    void (*printer) __P((void *, char *, ...));
+    void (*printer)(void *, char *, ...);
     void *arg;
 {
 	printer(arg, "%s", epdisc_to_str(&lcp_wantoptions[0].endpoint));
@@ -1997,7 +1997,7 @@ static int
 lcp_printpkt(p, plen, printer, arg)
     u_char *p;
     int plen;
-    void (*printer) __P((void *, char *, ...));
+    void (*printer)(void *, char *, ...);
     void *arg;
 {
     int code, id, len, olen, i;

--- a/pppd/lcp.h
+++ b/pppd/lcp.h
@@ -122,11 +122,11 @@ extern lcp_options lcp_hisoptions[];
 #define MINMRU	128		/* No MRUs below this */
 #define MAXMRU	16384		/* Normally limit MRU to this */
 
-void lcp_open __P((int));
-void lcp_close __P((int, char *));
-void lcp_lowerup __P((int));
-void lcp_lowerdown __P((int));
-void lcp_sprotrej __P((int, u_char *, int));	/* send protocol reject */
+void lcp_open(int);
+void lcp_close(int, char *);
+void lcp_lowerup(int);
+void lcp_lowerdown(int);
+void lcp_sprotrej(int, u_char *, int);	/* send protocol reject */
 
 extern struct protent lcp_protent;
 

--- a/pppd/main.c
+++ b/pppd/main.c
@@ -157,10 +157,10 @@ TDB_CONTEXT *pppdb;		/* database for storing status etc. */
 
 char db_key[32];
 
-int (*holdoff_hook) __P((void)) = NULL;
-int (*new_phase_hook) __P((int)) = NULL;
-void (*snoop_recv_hook) __P((unsigned char *p, int len)) = NULL;
-void (*snoop_send_hook) __P((unsigned char *p, int len)) = NULL;
+int (*holdoff_hook)(void) = NULL;
+int (*new_phase_hook)(int) = NULL;
+void (*snoop_recv_hook)(unsigned char *p, int len) = NULL;
+void (*snoop_send_hook)(unsigned char *p, int len) = NULL;
 
 static int conn_running;	/* we have a [dis]connector running */
 static int fd_loop;		/* fd for getting demand-dial packets */
@@ -216,7 +216,7 @@ bool bundle_terminating;
 struct subprocess {
     pid_t	pid;
     char	*prog;
-    void	(*done) __P((void *));
+    void	(*done)(void *);
     void	*arg;
     int		killable;
     struct subprocess *next;
@@ -226,37 +226,37 @@ static struct subprocess *children;
 
 /* Prototypes for procedures local to this file. */
 
-static void setup_signals __P((void));
-static void create_pidfile __P((int pid));
-static void create_linkpidfile __P((int pid));
-static void cleanup __P((void));
-static void get_input __P((void));
-static void calltimeout __P((void));
-static struct timeval *timeleft __P((struct timeval *));
-static void kill_my_pg __P((int));
-static void hup __P((int));
-static void term __P((int));
-static void chld __P((int));
-static void toggle_debug __P((int));
-static void open_ccp __P((int));
-static void bad_signal __P((int));
-static void holdoff_end __P((void *));
-static void forget_child __P((int pid, int status));
-static int reap_kids __P((void));
-static void childwait_end __P((void *));
+static void setup_signals(void);
+static void create_pidfile(int pid);
+static void create_linkpidfile(int pid);
+static void cleanup(void);
+static void get_input(void);
+static void calltimeout(void);
+static struct timeval *timeleft(struct timeval *);
+static void kill_my_pg(int);
+static void hup(int);
+static void term(int);
+static void chld(int);
+static void toggle_debug(int);
+static void open_ccp(int);
+static void bad_signal(int);
+static void holdoff_end(void *);
+static void forget_child(int pid, int status);
+static int reap_kids(void);
+static void childwait_end(void *);
 
 #ifdef USE_TDB
-static void update_db_entry __P((void));
-static void add_db_key __P((const char *));
-static void delete_db_key __P((const char *));
-static void cleanup_db __P((void));
+static void update_db_entry(void);
+static void add_db_key(const char *);
+static void delete_db_key(const char *);
+static void cleanup_db(void);
 #endif
 
-static void handle_events __P((void));
-void print_link_stats __P((void));
+static void handle_events(void);
+void print_link_stats(void);
 
-extern	char	*getlogin __P((void));
-int main __P((int, char *[]));
+extern	char	*getlogin(void);
+int main(int, char *[]);
 
 #ifdef ultrix
 #undef	O_NONBLOCK
@@ -1264,7 +1264,7 @@ update_link_stats(u)
 struct	callout {
     struct timeval	c_time;		/* time at which to call routine */
     void		*c_arg;		/* argument to routine */
-    void		(*c_func) __P((void *)); /* routine */
+    void		(*c_func)(void *); /* routine */
     struct		callout *c_next;
 };
 
@@ -1276,7 +1276,7 @@ static struct timeval timenow;		/* Current time */
  */
 void
 timeout(func, arg, secs, usecs)
-    void (*func) __P((void *));
+    void (*func)(void *);
     void *arg;
     int secs, usecs;
 {
@@ -1315,7 +1315,7 @@ timeout(func, arg, secs, usecs)
  */
 void
 untimeout(func, arg)
-    void (*func) __P((void *));
+    void (*func)(void *);
     void *arg;
 {
     struct callout **copp, *freep;
@@ -1785,7 +1785,7 @@ run_program(prog, args, must_exist, done, arg, wait)
     char *prog;
     char **args;
     int must_exist;
-    void (*done) __P((void *));
+    void (*done)(void *);
     void *arg;
     int wait;
 {
@@ -1861,7 +1861,7 @@ void
 record_child(pid, prog, done, arg, killable)
     int pid;
     char *prog;
-    void (*done) __P((void *));
+    void (*done)(void *);
     void *arg;
     int killable;
 {

--- a/pppd/md4.h
+++ b/pppd/md4.h
@@ -8,15 +8,6 @@
 ** ********************************************************************
 */
 
-#ifndef __P
-# if defined(__STDC__) || defined(__GNUC__)
-#  define __P(x) x
-# else
-#  define __P(x) ()
-# endif
-#endif
-
-
 /* MDstruct is the data structure for a message digest computation.
 */
 typedef struct {
@@ -29,7 +20,7 @@ typedef struct {
 ** Initialize the MD4_CTX prepatory to doing a message digest
 ** computation.
 */
-extern void MD4Init __P((MD4_CTX *MD));
+extern void MD4Init(MD4_CTX *MD);
 
 /* MD4Update(MD,X,count)
 ** Input: X -- a pointer to an array of unsigned characters.
@@ -43,7 +34,7 @@ extern void MD4Init __P((MD4_CTX *MD));
 ** every MD computation should end with one call to MD4Update with a
 ** count less than 512.  Zero is OK for a count.
 */
-extern void MD4Update __P((MD4_CTX *MD, unsigned char *X, unsigned int count));
+extern void MD4Update(MD4_CTX *MD, unsigned char *X, unsigned int count);
 
 /* MD4Print(MD)
 ** Prints message digest buffer MD as 32 hexadecimal digits.
@@ -51,13 +42,13 @@ extern void MD4Update __P((MD4_CTX *MD, unsigned char *X, unsigned int count));
 ** of buffer[3].
 ** Each byte is printed with high-order hexadecimal digit first.
 */
-extern void MD4Print __P((MD4_CTX *));
+extern void MD4Print(MD4_CTX *);
 
 /* MD4Final(buf, MD)
 ** Returns message digest from MD and terminates the message
 ** digest computation.
 */
-extern void MD4Final __P((unsigned char *, MD4_CTX *));
+extern void MD4Final(unsigned char *, MD4_CTX *);
 
 /*
 ** End of md4.h

--- a/pppd/multilink.c
+++ b/pppd/multilink.c
@@ -50,13 +50,13 @@ bool multilink_master;		/* we own the multilink bundle */
 extern TDB_CONTEXT *pppdb;
 extern char db_key[];
 
-static void make_bundle_links __P((int append));
-static void remove_bundle_link __P((void));
-static void iterate_bundle_links __P((void (*func) __P((char *))));
+static void make_bundle_links(int append);
+static void remove_bundle_link(void);
+static void iterate_bundle_links(void (*func)(char *));
 
-static int get_default_epdisc __P((struct epdisc *));
-static int parse_num __P((char *str, const char *key, int *valp));
-static int owns_unit __P((TDB_DATA pid, int unit));
+static int get_default_epdisc(struct epdisc *);
+static int parse_num(char *str, const char *key, int *valp);
+static int owns_unit(TDB_DATA pid, int unit);
 
 #define set_ip_epdisc(ep, addr) do {	\
 	ep->length = 4;			\

--- a/pppd/options.c
+++ b/pppd/options.c
@@ -76,7 +76,7 @@
 #include "pathnames.h"
 
 #if defined(ultrix) || defined(NeXT)
-char *strdup __P((char *));
+char *strdup(char *);
 #endif
 
 
@@ -154,35 +154,35 @@ static char logfile_name[MAXPATHLEN];	/* name of log file */
 /*
  * Prototypes
  */
-static int setdomain __P((char **));
-static int readfile __P((char **));
-static int callfile __P((char **));
-static int showversion __P((char **));
-static int showhelp __P((char **));
-static void usage __P((void));
-static int setlogfile __P((char **));
+static int setdomain(char **);
+static int readfile(char **);
+static int callfile(char **);
+static int showversion(char **);
+static int showhelp(char **);
+static void usage(void);
+static int setlogfile(char **);
 #ifdef PLUGIN
-static int loadplugin __P((char **));
+static int loadplugin(char **);
 #endif
 
 #ifdef PPP_FILTER
-static int setpassfilter __P((char **));
-static int setactivefilter __P((char **));
+static int setpassfilter(char **);
+static int setactivefilter(char **);
 #endif
 
 #ifdef MAXOCTETS
-static int setmodir __P((char **));
+static int setmodir(char **);
 #endif
 
-static int user_setenv __P((char **));
-static void user_setprint __P((option_t *, printer_func, void *));
-static int user_unsetenv __P((char **));
-static void user_unsetprint __P((option_t *, printer_func, void *));
+static int user_setenv(char **);
+static void user_setprint(option_t *, printer_func, void *);
+static int user_unsetenv(char **);
+static void user_unsetprint(option_t *, printer_func, void *);
 
-static option_t *find_option __P((const char *name));
-static int process_option __P((option_t *, char *, char **));
-static int n_arguments __P((option_t *));
-static int number_option __P((char *, u_int32_t *, int));
+static option_t *find_option(const char *name);
+static int process_option(option_t *, char *, char **);
+static int n_arguments(option_t *);
+static int number_option(char *, u_int32_t *, int);
 
 /*
  * Structure to store extra lists of options.
@@ -612,13 +612,13 @@ match_option(name, opt, dowild)
     option_t *opt;
     int dowild;
 {
-	int (*match) __P((char *, char **, int));
+	int (*match)(char *, char **, int);
 
 	if (dowild != (opt->type == o_wild))
 		return 0;
 	if (!dowild)
 		return strcmp(name, opt->name) == 0;
-	match = (int (*) __P((char *, char **, int))) opt->addr;
+	match = (int (*)(char *, char **, int)) opt->addr;
 	return (*match)(name, NULL, 0);
 }
 
@@ -670,8 +670,8 @@ process_option(opt, cmd, argv)
     u_int32_t v;
     int iv, a;
     char *sv;
-    int (*parser) __P((char **));
-    int (*wildp) __P((char *, char **, int));
+    int (*parser)(char **);
+    int (*wildp)(char *, char **, int);
     char *optopt = (opt->type == o_wild)? "": " option";
     int prio = option_priority;
     option_t *mainopt = opt;
@@ -810,7 +810,7 @@ process_option(opt, cmd, argv)
 
     case o_special_noarg:
     case o_special:
-	parser = (int (*) __P((char **))) opt->addr;
+	parser = (int (*)(char **)) opt->addr;
 	curopt = opt;
 	if (!(*parser)(argv))
 	    return 0;
@@ -834,7 +834,7 @@ process_option(opt, cmd, argv)
 	break;
 
     case o_wild:
-	wildp = (int (*) __P((char *, char **, int))) opt->addr;
+	wildp = (int (*)(char *, char **, int)) opt->addr;
 	if (!(*wildp)(cmd, argv, 1))
 	    return 0;
 	break;
@@ -988,9 +988,9 @@ print_option(opt, mainopt, printer, arg)
 			printer(arg, " ");
 		}
 		if (opt->flags & OPT_A2PRINTER) {
-			void (*oprt) __P((option_t *, printer_func, void *));
-			oprt = (void (*) __P((option_t *, printer_func,
-					 void *)))opt->addr2;
+			void (*oprt)(option_t *, printer_func, void *);
+			oprt = (void (*)(option_t *, printer_func,
+					 void *))opt->addr2;
 			(*oprt)(opt, printer, arg);
 		} else if (opt->flags & OPT_A2STRVAL) {
 			p = (char *) opt->addr2;
@@ -1620,7 +1620,7 @@ loadplugin(argv)
     char *arg = *argv;
     void *handle;
     const char *err;
-    void (*init) __P((void));
+    void (*init)(void);
     char *path = arg;
     const char *vers;
 

--- a/pppd/plugins/radius/radiusclient.h
+++ b/pppd/plugins/radius/radiusclient.h
@@ -386,75 +386,75 @@ typedef struct env
 
 /*	avpair.c		*/
 
-VALUE_PAIR *rc_avpair_add __P((VALUE_PAIR **, int, void *, int, int));
-int rc_avpair_assign __P((VALUE_PAIR *, void *, int));
-VALUE_PAIR *rc_avpair_new __P((int, void *, int, int));
-VALUE_PAIR *rc_avpair_gen __P((AUTH_HDR *));
-VALUE_PAIR *rc_avpair_get __P((VALUE_PAIR *, UINT4));
-VALUE_PAIR *rc_avpair_copy __P((VALUE_PAIR *));
-void rc_avpair_insert __P((VALUE_PAIR **, VALUE_PAIR *, VALUE_PAIR *));
-void rc_avpair_free __P((VALUE_PAIR *));
-int rc_avpair_parse __P((char *, VALUE_PAIR **));
-int rc_avpair_tostr __P((VALUE_PAIR *, char *, int, char *, int));
-VALUE_PAIR *rc_avpair_readin __P((FILE *));
+VALUE_PAIR *rc_avpair_add(VALUE_PAIR **, int, void *, int, int);
+int rc_avpair_assign(VALUE_PAIR *, void *, int);
+VALUE_PAIR *rc_avpair_new(int, void *, int, int);
+VALUE_PAIR *rc_avpair_gen(AUTH_HDR *);
+VALUE_PAIR *rc_avpair_get(VALUE_PAIR *, UINT4);
+VALUE_PAIR *rc_avpair_copy(VALUE_PAIR *);
+void rc_avpair_insert(VALUE_PAIR **, VALUE_PAIR *, VALUE_PAIR *);
+void rc_avpair_free(VALUE_PAIR *);
+int rc_avpair_parse(char *, VALUE_PAIR **);
+int rc_avpair_tostr(VALUE_PAIR *, char *, int, char *, int);
+VALUE_PAIR *rc_avpair_readin(FILE *);
 
 /*	buildreq.c		*/
 
-void rc_buildreq __P((SEND_DATA *, int, char *, unsigned short, int, int));
-unsigned char rc_get_seqnbr __P((void));
-int rc_auth __P((UINT4, VALUE_PAIR *, VALUE_PAIR **, char *, REQUEST_INFO *));
-int rc_auth_using_server __P((SERVER *, UINT4, VALUE_PAIR *, VALUE_PAIR **,
-			      char *, REQUEST_INFO *));
-int rc_auth_proxy __P((VALUE_PAIR *, VALUE_PAIR **, char *));
-int rc_acct __P((UINT4, VALUE_PAIR *));
-int rc_acct_using_server __P((SERVER *, UINT4, VALUE_PAIR *));
-int rc_acct_proxy __P((VALUE_PAIR *));
-int rc_check __P((char *, unsigned short, char *));
+void rc_buildreq(SEND_DATA *, int, char *, unsigned short, int, int);
+unsigned char rc_get_seqnbr(void);
+int rc_auth(UINT4, VALUE_PAIR *, VALUE_PAIR **, char *, REQUEST_INFO *);
+int rc_auth_using_server(SERVER *, UINT4, VALUE_PAIR *, VALUE_PAIR **,
+			      char *, REQUEST_INFO *);
+int rc_auth_proxy(VALUE_PAIR *, VALUE_PAIR **, char *);
+int rc_acct(UINT4, VALUE_PAIR *);
+int rc_acct_using_server(SERVER *, UINT4, VALUE_PAIR *);
+int rc_acct_proxy(VALUE_PAIR *);
+int rc_check(char *, unsigned short, char *);
 
 /*	clientid.c		*/
 
-int rc_read_mapfile __P((char *));
-UINT4 rc_map2id __P((char *));
+int rc_read_mapfile(char *);
+UINT4 rc_map2id(char *);
 
 /*	config.c		*/
 
-int rc_read_config __P((char *));
-char *rc_conf_str __P((char *));
-int rc_conf_int __P((char *));
-SERVER *rc_conf_srv __P((char *));
-int rc_find_server __P((char *, UINT4 *, char *));
+int rc_read_config(char *);
+char *rc_conf_str(char *);
+int rc_conf_int(char *);
+SERVER *rc_conf_srv(char *);
+int rc_find_server(char *, UINT4 *, char *);
 
 /*	dict.c			*/
 
-int rc_read_dictionary __P((char *));
-DICT_ATTR *rc_dict_getattr __P((int, int));
-DICT_ATTR *rc_dict_findattr __P((char *));
-DICT_VALUE *rc_dict_findval __P((char *));
-DICT_VALUE * rc_dict_getval __P((UINT4, char *));
-VENDOR_DICT * rc_dict_findvendor __P((char *));
-VENDOR_DICT * rc_dict_getvendor __P((int));
+int rc_read_dictionary(char *);
+DICT_ATTR *rc_dict_getattr(int, int);
+DICT_ATTR *rc_dict_findattr(char *);
+DICT_VALUE *rc_dict_findval(char *);
+DICT_VALUE * rc_dict_getval(UINT4, char *);
+VENDOR_DICT * rc_dict_findvendor(char *);
+VENDOR_DICT * rc_dict_getvendor(int);
 
 /*	ip_util.c		*/
 
-UINT4 rc_get_ipaddr __P((char *));
-int rc_good_ipaddr __P((char *));
-const char *rc_ip_hostname __P((UINT4));
-UINT4 rc_own_ipaddress __P((void));
-UINT4 rc_own_bind_ipaddress __P((void));
+UINT4 rc_get_ipaddr(char *);
+int rc_good_ipaddr(char *);
+const char *rc_ip_hostname(UINT4);
+UINT4 rc_own_ipaddress(void);
+UINT4 rc_own_bind_ipaddress(void);
 
 
 /*	sendserver.c		*/
 
-int rc_send_server __P((SEND_DATA *, char *, REQUEST_INFO *));
+int rc_send_server(SEND_DATA *, char *, REQUEST_INFO *);
 
 /*	util.c			*/
 
-void rc_str2tm __P((char *, struct tm *));
-char *rc_mksid __P((void));
-void rc_mdelay __P((int));
+void rc_str2tm(char *, struct tm *);
+char *rc_mksid(void);
+void rc_mdelay(int);
 
 /* md5.c			*/
 
-void rc_md5_calc __P((unsigned char *, unsigned char *, unsigned int));
+void rc_md5_calc(unsigned char *, unsigned char *, unsigned int);
 
 #endif /* RADIUSCLIENT_H */

--- a/pppd/pppcrypt.h
+++ b/pppd/pppcrypt.h
@@ -41,8 +41,8 @@
 #include <des.h>
 #endif
 
-extern bool	DesSetkey __P((u_char *));
-extern bool	DesEncrypt __P((u_char *, u_char *));
-extern bool	DesDecrypt __P((u_char *, u_char *));
+extern bool	DesSetkey(u_char *);
+extern bool	DesEncrypt(u_char *, u_char *);
+extern bool	DesDecrypt(u_char *, u_char *);
 
 #endif /* PPPCRYPT_H */

--- a/pppd/pppd.h
+++ b/pppd/pppd.h
@@ -210,8 +210,8 @@ struct epdisc {
 #define EPD_MAGIC	4
 #define EPD_PHONENUM	5
 
-typedef void (*notify_func) __P((void *, int));
-typedef void (*printer_func) __P((void *, char *, ...));
+typedef void (*notify_func)(void *, int);
+typedef void (*printer_func)(void *, char *, ...);
 
 struct notifier {
     struct notifier *next;
@@ -420,34 +420,34 @@ extern int  option_priority;	/* priority of current options */
 struct protent {
     u_short protocol;		/* PPP protocol number */
     /* Initialization procedure */
-    void (*init) __P((int unit));
+    void (*init)(int unit);
     /* Process a received packet */
-    void (*input) __P((int unit, u_char *pkt, int len));
+    void (*input)(int unit, u_char *pkt, int len);
     /* Process a received protocol-reject */
-    void (*protrej) __P((int unit));
+    void (*protrej)(int unit);
     /* Lower layer has come up */
-    void (*lowerup) __P((int unit));
+    void (*lowerup)(int unit);
     /* Lower layer has gone down */
-    void (*lowerdown) __P((int unit));
+    void (*lowerdown)(int unit);
     /* Open the protocol */
-    void (*open) __P((int unit));
+    void (*open)(int unit);
     /* Close the protocol */
-    void (*close) __P((int unit, char *reason));
+    void (*close)(int unit, char *reason);
     /* Print a packet in readable form */
-    int  (*printpkt) __P((u_char *pkt, int len, printer_func printer,
-			  void *arg));
+    int  (*printpkt)(u_char *pkt, int len, printer_func printer,
+			  void *arg);
     /* Process a received data packet */
-    void (*datainput) __P((int unit, u_char *pkt, int len));
+    void (*datainput)(int unit, u_char *pkt, int len);
     bool enabled_flag;		/* 0 iff protocol is disabled */
     char *name;			/* Text name of protocol */
     char *data_name;		/* Text name of corresponding data protocol */
     option_t *options;		/* List of command-line options */
     /* Check requested options, assign defaults */
-    void (*check_options) __P((void));
+    void (*check_options)(void);
     /* Configure interface for demand-dial */
-    int  (*demand_conf) __P((int unit));
+    int  (*demand_conf)(int unit);
     /* Say whether to bring up link for this pkt */
-    int  (*active_pkt) __P((u_char *pkt, int len));
+    int  (*active_pkt)(u_char *pkt, int len);
 };
 
 /* Table of pointers to supported protocols */
@@ -464,25 +464,25 @@ struct channel {
 	/* set of options for this channel */
 	option_t *options;
 	/* find and process a per-channel options file */
-	void (*process_extra_options) __P((void));
+	void (*process_extra_options)(void);
 	/* check all the options that have been given */
-	void (*check_options) __P((void));
+	void (*check_options)(void);
 	/* get the channel ready to do PPP, return a file descriptor */
-	int  (*connect) __P((void));
+	int  (*connect)(void);
 	/* we're finished with the channel */
-	void (*disconnect) __P((void));
+	void (*disconnect)(void);
 	/* put the channel into PPP `mode' */
-	int  (*establish_ppp) __P((int));
+	int  (*establish_ppp)(int);
 	/* take the channel out of PPP `mode', restore loopback if demand */
-	void (*disestablish_ppp) __P((int));
+	void (*disestablish_ppp)(int);
 	/* set the transmit-side PPP parameters of the channel */
-	void (*send_config) __P((int, u_int32_t, int, int));
+	void (*send_config)(int, u_int32_t, int, int);
 	/* set the receive-side PPP parameters of the channel */
-	void (*recv_config) __P((int, u_int32_t, int, int));
+	void (*recv_config)(int, u_int32_t, int, int);
 	/* cleanup on error or normal exit */
-	void (*cleanup) __P((void));
+	void (*cleanup)(void);
 	/* close the device, called in children after fork */
-	void (*close) __P((void));
+	void (*close)(void);
 };
 
 extern struct channel *the_channel;
@@ -507,117 +507,117 @@ extern struct userenv *userenv_list;
  */
 
 /* Procedures exported from main.c. */
-void set_ifunit __P((int));	/* set stuff that depends on ifunit */
-void detach __P((void));	/* Detach from controlling tty */
-void die __P((int));		/* Cleanup and exit */
-void quit __P((void));		/* like die(1) */
-void novm __P((char *));	/* Say we ran out of memory, and die */
-void timeout __P((void (*func)(void *), void *arg, int s, int us));
+void set_ifunit(int);	/* set stuff that depends on ifunit */
+void detach(void);	/* Detach from controlling tty */
+void die(int);		/* Cleanup and exit */
+void quit(void);		/* like die(1) */
+void novm(char *);	/* Say we ran out of memory, and die */
+void timeout(void (*func)(void *), void *arg, int s, int us);
 				/* Call func(arg) after s.us seconds */
-void untimeout __P((void (*func)(void *), void *arg));
+void untimeout(void (*func)(void *), void *arg);
 				/* Cancel call to func(arg) */
-void record_child __P((int, char *, void (*) (void *), void *, int));
-pid_t safe_fork __P((int, int, int));	/* Fork & close stuff in child */
-int  device_script __P((char *cmd, int in, int out, int dont_wait));
+void record_child(int, char *, void (*) (void *), void *, int);
+pid_t safe_fork(int, int, int);	/* Fork & close stuff in child */
+int  device_script(char *cmd, int in, int out, int dont_wait);
 				/* Run `cmd' with given stdin and stdout */
-pid_t run_program __P((char *prog, char **args, int must_exist,
-		       void (*done)(void *), void *arg, int wait));
+pid_t run_program(char *prog, char **args, int must_exist,
+		       void (*done)(void *), void *arg, int wait);
 				/* Run program prog with args in child */
-void reopen_log __P((void));	/* (re)open the connection to syslog */
-void print_link_stats __P((void)); /* Print stats, if available */
-void reset_link_stats __P((int)); /* Reset (init) stats when link goes up */
-void update_link_stats __P((int)); /* Get stats at link termination */
-void script_setenv __P((char *, char *, int));	/* set script env var */
-void script_unsetenv __P((char *));		/* unset script env var */
-void new_phase __P((int));	/* signal start of new phase */
-void add_notifier __P((struct notifier **, notify_func, void *));
-void remove_notifier __P((struct notifier **, notify_func, void *));
-void notify __P((struct notifier *, int));
-int  ppp_send_config __P((int, int, u_int32_t, int, int));
-int  ppp_recv_config __P((int, int, u_int32_t, int, int));
-const char *protocol_name __P((int));
-void remove_pidfiles __P((void));
-void lock_db __P((void));
-void unlock_db __P((void));
+void reopen_log(void);	/* (re)open the connection to syslog */
+void print_link_stats(void); /* Print stats, if available */
+void reset_link_stats(int); /* Reset (init) stats when link goes up */
+void update_link_stats(int); /* Get stats at link termination */
+void script_setenv(char *, char *, int);	/* set script env var */
+void script_unsetenv(char *);		/* unset script env var */
+void new_phase(int);	/* signal start of new phase */
+void add_notifier(struct notifier **, notify_func, void *);
+void remove_notifier(struct notifier **, notify_func, void *);
+void notify(struct notifier *, int);
+int  ppp_send_config(int, int, u_int32_t, int, int);
+int  ppp_recv_config(int, int, u_int32_t, int, int);
+const char *protocol_name(int);
+void remove_pidfiles(void);
+void lock_db(void);
+void unlock_db(void);
 
 /* Procedures exported from tty.c. */
-void tty_init __P((void));
+void tty_init(void);
 
 /* Procedures exported from utils.c. */
-void log_packet __P((u_char *, int, char *, int));
+void log_packet(u_char *, int, char *, int);
 				/* Format a packet and log it with syslog */
-void print_string __P((char *, int,  printer_func, void *));
+void print_string(char *, int,  printer_func, void *);
 				/* Format a string for output */
-int slprintf __P((char *, int, char *, ...));		/* sprintf++ */
-int vslprintf __P((char *, int, char *, va_list));	/* vsprintf++ */
-size_t strlcpy __P((char *, const char *, size_t));	/* safe strcpy */
-size_t strlcat __P((char *, const char *, size_t));	/* safe strncpy */
-void dbglog __P((char *, ...));	/* log a debug message */
-void info __P((char *, ...));	/* log an informational message */
-void notice __P((char *, ...));	/* log a notice-level message */
-void warn __P((char *, ...));	/* log a warning message */
-void error __P((char *, ...));	/* log an error message */
-void fatal __P((char *, ...));	/* log an error message and die(1) */
-void init_pr_log __P((const char *, int)); /* initialize for using pr_log */
-void pr_log __P((void *, char *, ...));	/* printer fn, output to syslog */
-void end_pr_log __P((void));	/* finish up after using pr_log */
-void dump_packet __P((const char *, u_char *, int));
+int slprintf(char *, int, char *, ...);		/* sprintf++ */
+int vslprintf(char *, int, char *, va_list);	/* vsprintf++ */
+size_t strlcpy(char *, const char *, size_t);	/* safe strcpy */
+size_t strlcat(char *, const char *, size_t);	/* safe strncpy */
+void dbglog(char *, ...);	/* log a debug message */
+void info(char *, ...);	/* log an informational message */
+void notice(char *, ...);	/* log a notice-level message */
+void warn(char *, ...);	/* log a warning message */
+void error(char *, ...);	/* log an error message */
+void fatal(char *, ...);	/* log an error message and die(1) */
+void init_pr_log(const char *, int); /* initialize for using pr_log */
+void pr_log(void *, char *, ...);	/* printer fn, output to syslog */
+void end_pr_log(void);	/* finish up after using pr_log */
+void dump_packet(const char *, u_char *, int);
 				/* dump packet to debug log if interesting */
-ssize_t complete_read __P((int, void *, size_t));
+ssize_t complete_read(int, void *, size_t);
 				/* read a complete buffer */
 
 /* Procedures exported from auth.c */
-void link_required __P((int));	  /* we are starting to use the link */
-void start_link __P((int));	  /* bring the link up now */
-void link_terminated __P((int));  /* we are finished with the link */
-void link_down __P((int));	  /* the LCP layer has left the Opened state */
-void upper_layers_down __P((int));/* take all NCPs down */
-void link_established __P((int)); /* the link is up; authenticate now */
-void start_networks __P((int));   /* start all the network control protos */
-void continue_networks __P((int)); /* start network [ip, etc] control protos */
-void np_up __P((int, int));	  /* a network protocol has come up */
-void np_down __P((int, int));	  /* a network protocol has gone down */
-void np_finished __P((int, int)); /* a network protocol no longer needs link */
-void auth_peer_fail __P((int, int));
+void link_required(int);	  /* we are starting to use the link */
+void start_link(int);	  /* bring the link up now */
+void link_terminated(int);  /* we are finished with the link */
+void link_down(int);	  /* the LCP layer has left the Opened state */
+void upper_layers_down(int);/* take all NCPs down */
+void link_established(int); /* the link is up; authenticate now */
+void start_networks(int);   /* start all the network control protos */
+void continue_networks(int); /* start network [ip, etc] control protos */
+void np_up(int, int);	  /* a network protocol has come up */
+void np_down(int, int);	  /* a network protocol has gone down */
+void np_finished(int, int); /* a network protocol no longer needs link */
+void auth_peer_fail(int, int);
 				/* peer failed to authenticate itself */
-void auth_peer_success __P((int, int, int, char *, int));
+void auth_peer_success(int, int, int, char *, int);
 				/* peer successfully authenticated itself */
-void auth_withpeer_fail __P((int, int));
+void auth_withpeer_fail(int, int);
 				/* we failed to authenticate ourselves */
-void auth_withpeer_success __P((int, int, int));
+void auth_withpeer_success(int, int, int);
 				/* we successfully authenticated ourselves */
-void auth_check_options __P((void));
+void auth_check_options(void);
 				/* check authentication options supplied */
-void auth_reset __P((int));	/* check what secrets we have */
-int  check_passwd __P((int, char *, int, char *, int, char **));
+void auth_reset(int);	/* check what secrets we have */
+int  check_passwd(int, char *, int, char *, int, char **);
 				/* Check peer-supplied username/password */
-int  get_secret __P((int, char *, char *, char *, int *, int));
+int  get_secret(int, char *, char *, char *, int *, int);
 				/* get "secret" for chap */
-int  get_srp_secret __P((int unit, char *client, char *server, char *secret,
-    int am_server));
-int  auth_ip_addr __P((int, u_int32_t));
+int  get_srp_secret(int unit, char *client, char *server, char *secret,
+    int am_server);
+int  auth_ip_addr(int, u_int32_t);
 				/* check if IP address is authorized */
-int  auth_number __P((void));	/* check if remote number is authorized */
-int  bad_ip_adrs __P((u_int32_t));
+int  auth_number(void);	/* check if remote number is authorized */
+int  bad_ip_adrs(u_int32_t);
 				/* check if IP address is unreasonable */
 
 /* Procedures exported from demand.c */
-void demand_conf __P((void));	/* config interface(s) for demand-dial */
-void demand_block __P((void));	/* set all NPs to queue up packets */
-void demand_unblock __P((void)); /* set all NPs to pass packets */
-void demand_discard __P((void)); /* set all NPs to discard packets */
-void demand_rexmit __P((int));	/* retransmit saved frames for an NP */
-int  loop_chars __P((unsigned char *, int)); /* process chars from loopback */
-int  loop_frame __P((unsigned char *, int)); /* should we bring link up? */
+void demand_conf(void);	/* config interface(s) for demand-dial */
+void demand_block(void);	/* set all NPs to queue up packets */
+void demand_unblock(void); /* set all NPs to pass packets */
+void demand_discard(void); /* set all NPs to discard packets */
+void demand_rexmit(int);	/* retransmit saved frames for an NP */
+int  loop_chars(unsigned char *, int); /* process chars from loopback */
+int  loop_frame(unsigned char *, int); /* should we bring link up? */
 
 /* Procedures exported from multilink.c */
 #ifdef HAVE_MULTILINK
-void mp_check_options __P((void)); /* Check multilink-related options */
-int  mp_join_bundle __P((void));  /* join our link to an appropriate bundle */
-void mp_exit_bundle __P((void));  /* have disconnected our link from bundle */
-void mp_bundle_terminated __P((void));
-char *epdisc_to_str __P((struct epdisc *)); /* string from endpoint discrim. */
-int  str_to_epdisc __P((struct epdisc *, char *)); /* endpt disc. from str */
+void mp_check_options(void); /* Check multilink-related options */
+int  mp_join_bundle(void);  /* join our link to an appropriate bundle */
+void mp_exit_bundle(void);  /* have disconnected our link from bundle */
+void mp_bundle_terminated(void);
+char *epdisc_to_str(struct epdisc *); /* string from endpoint discrim. */
+int  str_to_epdisc(struct epdisc *, char *); /* endpt disc. from str */
 #else
 #define mp_bundle_terminated()	/* nothing */
 #define mp_exit_bundle()	/* nothing */
@@ -626,159 +626,159 @@ int  str_to_epdisc __P((struct epdisc *, char *)); /* endpt disc. from str */
 #endif
 
 /* Procedures exported from sys-*.c */
-void sys_init __P((void));	/* Do system-dependent initialization */
-void sys_cleanup __P((void));	/* Restore system state before exiting */
-int  sys_check_options __P((void)); /* Check options specified */
-void sys_close __P((void));	/* Clean up in a child before execing */
-int  ppp_available __P((void));	/* Test whether ppp kernel support exists */
-int  get_pty __P((int *, int *, char *, int));	/* Get pty master/slave */
-int  open_ppp_loopback __P((void)); /* Open loopback for demand-dialling */
-int  tty_establish_ppp __P((int));  /* Turn serial port into a ppp interface */
-void tty_disestablish_ppp __P((int)); /* Restore port to normal operation */
-void generic_disestablish_ppp __P((int dev_fd)); /* Restore device setting */
-int  generic_establish_ppp __P((int dev_fd)); /* Make a ppp interface */
-void make_new_bundle __P((int, int, int, int)); /* Create new bundle */
-int  bundle_attach __P((int));	/* Attach link to existing bundle */
-void cfg_bundle __P((int, int, int, int)); /* Configure existing bundle */
-void destroy_bundle __P((void)); /* Tell driver to destroy bundle */
-void clean_check __P((void));	/* Check if line was 8-bit clean */
-void set_up_tty __P((int, int)); /* Set up port's speed, parameters, etc. */
-void restore_tty __P((int));	/* Restore port's original parameters */
-void setdtr __P((int, int));	/* Raise or lower port's DTR line */
-void output __P((int, u_char *, int)); /* Output a PPP packet */
-void wait_input __P((struct timeval *));
+void sys_init(void);	/* Do system-dependent initialization */
+void sys_cleanup(void);	/* Restore system state before exiting */
+int  sys_check_options(void); /* Check options specified */
+void sys_close(void);	/* Clean up in a child before execing */
+int  ppp_available(void);	/* Test whether ppp kernel support exists */
+int  get_pty(int *, int *, char *, int);	/* Get pty master/slave */
+int  open_ppp_loopback(void); /* Open loopback for demand-dialling */
+int  tty_establish_ppp(int);  /* Turn serial port into a ppp interface */
+void tty_disestablish_ppp(int); /* Restore port to normal operation */
+void generic_disestablish_ppp(int dev_fd); /* Restore device setting */
+int  generic_establish_ppp(int dev_fd); /* Make a ppp interface */
+void make_new_bundle(int, int, int, int); /* Create new bundle */
+int  bundle_attach(int);	/* Attach link to existing bundle */
+void cfg_bundle(int, int, int, int); /* Configure existing bundle */
+void destroy_bundle(void); /* Tell driver to destroy bundle */
+void clean_check(void);	/* Check if line was 8-bit clean */
+void set_up_tty(int, int); /* Set up port's speed, parameters, etc. */
+void restore_tty(int);	/* Restore port's original parameters */
+void setdtr(int, int);	/* Raise or lower port's DTR line */
+void output(int, u_char *, int); /* Output a PPP packet */
+void wait_input(struct timeval *);
 				/* Wait for input, with timeout */
-void add_fd __P((int));		/* Add fd to set to wait for */
-void remove_fd __P((int));	/* Remove fd from set to wait for */
-int  read_packet __P((u_char *)); /* Read PPP packet */
-int  get_loop_output __P((void)); /* Read pkts from loopback */
-void tty_send_config __P((int, u_int32_t, int, int));
+void add_fd(int);		/* Add fd to set to wait for */
+void remove_fd(int);	/* Remove fd from set to wait for */
+int  read_packet(u_char *); /* Read PPP packet */
+int  get_loop_output(void); /* Read pkts from loopback */
+void tty_send_config(int, u_int32_t, int, int);
 				/* Configure i/f transmit parameters */
-void tty_set_xaccm __P((ext_accm));
+void tty_set_xaccm(ext_accm);
 				/* Set extended transmit ACCM */
-void tty_recv_config __P((int, u_int32_t, int, int));
+void tty_recv_config(int, u_int32_t, int, int);
 				/* Configure i/f receive parameters */
-int  ccp_test __P((int, u_char *, int, int));
+int  ccp_test(int, u_char *, int, int);
 				/* Test support for compression scheme */
-void ccp_flags_set __P((int, int, int));
+void ccp_flags_set(int, int, int);
 				/* Set kernel CCP state */
-int  ccp_fatal_error __P((int)); /* Test for fatal decomp error in kernel */
-int  get_idle_time __P((int, struct ppp_idle *));
+int  ccp_fatal_error(int); /* Test for fatal decomp error in kernel */
+int  get_idle_time(int, struct ppp_idle *);
 				/* Find out how long link has been idle */
-int  get_ppp_stats __P((int, struct pppd_stats *));
+int  get_ppp_stats(int, struct pppd_stats *);
 				/* Return link statistics */
-void netif_set_mtu __P((int, int)); /* Set PPP interface MTU */
-int  netif_get_mtu __P((int));      /* Get PPP interface MTU */
-int  sifvjcomp __P((int, int, int, int));
+void netif_set_mtu(int, int); /* Set PPP interface MTU */
+int  netif_get_mtu(int);      /* Get PPP interface MTU */
+int  sifvjcomp(int, int, int, int);
 				/* Configure VJ TCP header compression */
-int  sifup __P((int));		/* Configure i/f up for one protocol */
-int  sifnpmode __P((int u, int proto, enum NPmode mode));
+int  sifup(int);		/* Configure i/f up for one protocol */
+int  sifnpmode(int u, int proto, enum NPmode mode);
 				/* Set mode for handling packets for proto */
-int  sifdown __P((int));	/* Configure i/f down for one protocol */
-int  sifaddr __P((int, u_int32_t, u_int32_t, u_int32_t));
+int  sifdown(int);	/* Configure i/f down for one protocol */
+int  sifaddr(int, u_int32_t, u_int32_t, u_int32_t);
 				/* Configure IPv4 addresses for i/f */
-int  cifaddr __P((int, u_int32_t, u_int32_t));
+int  cifaddr(int, u_int32_t, u_int32_t);
 				/* Reset i/f IP addresses */
 #ifdef INET6
 int  ether_to_eui64(eui64_t *p_eui64);	/* convert eth0 hw address to EUI64 */
-int  sif6up __P((int));		/* Configure i/f up for IPv6 */
-int  sif6down __P((int));	/* Configure i/f down for IPv6 */
-int  sif6addr __P((int, eui64_t, eui64_t));
+int  sif6up(int);		/* Configure i/f up for IPv6 */
+int  sif6down(int);	/* Configure i/f down for IPv6 */
+int  sif6addr(int, eui64_t, eui64_t);
 				/* Configure IPv6 addresses for i/f */
-int  cif6addr __P((int, eui64_t, eui64_t));
+int  cif6addr(int, eui64_t, eui64_t);
 				/* Remove an IPv6 address from i/f */
 #endif
-int  sifdefaultroute __P((int, u_int32_t, u_int32_t));
+int  sifdefaultroute(int, u_int32_t, u_int32_t);
 				/* Create default route through i/f */
-int  cifdefaultroute __P((int, u_int32_t, u_int32_t));
+int  cifdefaultroute(int, u_int32_t, u_int32_t);
 				/* Delete default route through i/f */
 #ifdef INET6
-int  sif6defaultroute __P((int, eui64_t, eui64_t));
+int  sif6defaultroute(int, eui64_t, eui64_t);
 				/* Create default IPv6 route through i/f */
-int  cif6defaultroute __P((int, eui64_t, eui64_t));
+int  cif6defaultroute(int, eui64_t, eui64_t);
 				/* Delete default IPv6 route through i/f */
 #endif
-int  sifproxyarp __P((int, u_int32_t));
+int  sifproxyarp(int, u_int32_t);
 				/* Add proxy ARP entry for peer */
-int  cifproxyarp __P((int, u_int32_t));
+int  cifproxyarp(int, u_int32_t);
 				/* Delete proxy ARP entry for peer */
-u_int32_t GetMask __P((u_int32_t)); /* Get appropriate netmask for address */
-int  lock __P((char *));	/* Create lock file for device */
-int  relock __P((int));		/* Rewrite lock file with new pid */
-void unlock __P((void));	/* Delete previously-created lock file */
-void logwtmp __P((const char *, const char *, const char *));
+u_int32_t GetMask(u_int32_t); /* Get appropriate netmask for address */
+int  lock(char *);	/* Create lock file for device */
+int  relock(int);		/* Rewrite lock file with new pid */
+void unlock(void);	/* Delete previously-created lock file */
+void logwtmp(const char *, const char *, const char *);
 				/* Write entry to wtmp file */
-int  get_host_seed __P((void));	/* Get host-dependent random number seed */
-int  have_route_to __P((u_int32_t)); /* Check if route to addr exists */
+int  get_host_seed(void);	/* Get host-dependent random number seed */
+int  have_route_to(u_int32_t); /* Check if route to addr exists */
 #ifdef PPP_FILTER
-int  set_filters __P((struct bpf_program *pass, struct bpf_program *active));
+int  set_filters(struct bpf_program *pass, struct bpf_program *active);
 				/* Set filter programs in kernel */
 #endif
 #ifdef IPX_CHANGE
-int  sipxfaddr __P((int, unsigned long, unsigned char *));
-int  cipxfaddr __P((int));
+int  sipxfaddr(int, unsigned long, unsigned char *);
+int  cipxfaddr(int);
 #endif
-int  get_if_hwaddr __P((u_char *addr, char *name));
-char *get_first_ethernet __P((void));
-int get_time __P((struct timeval *));
+int  get_if_hwaddr(u_char *addr, char *name);
+char *get_first_ethernet(void);
+int get_time(struct timeval *);
 				/* Get current time, monotonic if possible. */
 
 /* Procedures exported from options.c */
-int setipaddr __P((char *, char **, int)); /* Set local/remote ip addresses */
-int  parse_args __P((int argc, char **argv));
+int setipaddr(char *, char **, int); /* Set local/remote ip addresses */
+int  parse_args(int argc, char **argv);
 				/* Parse options from arguments given */
-int  options_from_file __P((char *filename, int must_exist, int check_prot,
-			    int privileged));
+int  options_from_file(char *filename, int must_exist, int check_prot,
+			    int privileged);
 				/* Parse options from an options file */
-int  options_from_user __P((void)); /* Parse options from user's .ppprc */
-int  options_for_tty __P((void)); /* Parse options from /etc/ppp/options.tty */
-int  options_from_list __P((struct wordlist *, int privileged));
+int  options_from_user(void); /* Parse options from user's .ppprc */
+int  options_for_tty(void); /* Parse options from /etc/ppp/options.tty */
+int  options_from_list(struct wordlist *, int privileged);
 				/* Parse options from a wordlist */
-int  getword __P((FILE *f, char *word, int *newlinep, char *filename));
+int  getword(FILE *f, char *word, int *newlinep, char *filename);
 				/* Read a word from a file */
-void option_error __P((char *fmt, ...));
+void option_error(char *fmt, ...);
 				/* Print an error message about an option */
-int int_option __P((char *, int *));
+int int_option(char *, int *);
 				/* Simplified number_option for decimal ints */
-void add_options __P((option_t *)); /* Add extra options */
-void check_options __P((void));	/* check values after all options parsed */
-int  override_value __P((const char *, int, const char *));
+void add_options(option_t *); /* Add extra options */
+void check_options(void);	/* check values after all options parsed */
+int  override_value(const char *, int, const char *);
 				/* override value if permitted by priority */
-void print_options __P((printer_func, void *));
+void print_options(printer_func, void *);
 				/* print out values of all options */
 
-int parse_dotted_ip __P((char *, u_int32_t *));
+int parse_dotted_ip(char *, u_int32_t *);
 
 /*
  * Hooks to enable plugins to change various things.
  */
-extern int (*new_phase_hook) __P((int));
-extern int (*idle_time_hook) __P((struct ppp_idle *));
-extern int (*holdoff_hook) __P((void));
-extern int (*pap_check_hook) __P((void));
-extern int (*pap_auth_hook) __P((char *user, char *passwd, char **msgp,
+extern int (*new_phase_hook)(int);
+extern int (*idle_time_hook)(struct ppp_idle *);
+extern int (*holdoff_hook)(void);
+extern int (*pap_check_hook)(void);
+extern int (*pap_auth_hook)(char *user, char *passwd, char **msgp,
 				 struct wordlist **paddrs,
-				 struct wordlist **popts));
-extern void (*pap_logout_hook) __P((void));
-extern int (*pap_passwd_hook) __P((char *user, char *passwd));
-extern int (*allowed_address_hook) __P((u_int32_t addr));
-extern void (*ip_up_hook) __P((void));
-extern void (*ip_down_hook) __P((void));
-extern void (*ip_choose_hook) __P((u_int32_t *));
-extern void (*ipv6_up_hook) __P((void));
-extern void (*ipv6_down_hook) __P((void));
+				 struct wordlist **popts);
+extern void (*pap_logout_hook)(void);
+extern int (*pap_passwd_hook)(char *user, char *passwd);
+extern int (*allowed_address_hook)(u_int32_t addr);
+extern void (*ip_up_hook)(void);
+extern void (*ip_down_hook)(void);
+extern void (*ip_choose_hook)(u_int32_t *);
+extern void (*ipv6_up_hook)(void);
+extern void (*ipv6_down_hook)(void);
 
-extern int (*chap_check_hook) __P((void));
-extern int (*chap_passwd_hook) __P((char *user, char *passwd));
-extern void (*multilink_join_hook) __P((void));
+extern int (*chap_check_hook)(void);
+extern int (*chap_passwd_hook)(char *user, char *passwd);
+extern void (*multilink_join_hook)(void);
 
 #ifdef USE_EAPTLS
 extern int (*eaptls_passwd_hook) __P((char *user, char *passwd));
 #endif
 
 /* Let a plugin snoop sent and received packets.  Useful for L2TP */
-extern void (*snoop_recv_hook) __P((unsigned char *p, int len));
-extern void (*snoop_send_hook) __P((unsigned char *p, int len));
+extern void (*snoop_recv_hook)(unsigned char *p, int len);
+extern void (*snoop_send_hook)(unsigned char *p, int len);
 
 /*
  * Inline versions of get/put char/short/long.

--- a/pppd/sys-solaris.c
+++ b/pppd/sys-solaris.c
@@ -256,15 +256,15 @@ static eui64_t	default_route_gateway6;	/* Gateway for default IPv6 route added *
 static u_int32_t proxy_arp_addr;	/* Addr for proxy arp entry added */
 
 /* Prototypes for procedures local to this file. */
-static int translate_speed __P((int));
-static int baud_rate_of __P((int));
-static int get_ether_addr __P((u_int32_t, struct sockaddr *));
-static int get_hw_addr __P((char *, u_int32_t, struct sockaddr *));
-static int get_hw_addr_dlpi __P((char *, struct sockaddr *));
-static int dlpi_attach __P((int, int));
-static int dlpi_info_req __P((int));
-static int dlpi_get_reply __P((int, union DL_primitives *, int, int));
-static int strioctl __P((int, int, void *, int, int));
+static int translate_speed(int);
+static int baud_rate_of(int);
+static int get_ether_addr(u_int32_t, struct sockaddr *);
+static int get_hw_addr(char *, u_int32_t, struct sockaddr *);
+static int get_hw_addr_dlpi(char *, struct sockaddr *);
+static int dlpi_attach(int, int);
+static int dlpi_info_req(int);
+static int dlpi_get_reply(int, union DL_primitives *, int, int);
+static int strioctl(int, int, void *, int, int);
 
 #ifdef SOL2
 /*

--- a/pppd/tty.c
+++ b/pppd/tty.c
@@ -97,28 +97,28 @@
 #include "fsm.h"
 #include "lcp.h"
 
-void tty_process_extra_options __P((void));
-void tty_check_options __P((void));
-int  connect_tty __P((void));
-void disconnect_tty __P((void));
-void tty_close_fds __P((void));
-void cleanup_tty __P((void));
-void tty_do_send_config __P((int, u_int32_t, int, int));
+void tty_process_extra_options(void);
+void tty_check_options(void);
+int  connect_tty(void);
+void disconnect_tty(void);
+void tty_close_fds(void);
+void cleanup_tty(void);
+void tty_do_send_config(int, u_int32_t, int, int);
 
-static int setdevname __P((char *, char **, int));
-static int setspeed __P((char *, char **, int));
-static int setxonxoff __P((char **));
-static int setescape __P((char **));
-static void printescape __P((option_t *, void (*)(void *, char *,...),void *));
-static void finish_tty __P((void));
-static int start_charshunt __P((int, int));
-static void stop_charshunt __P((void *, int));
-static void charshunt_done __P((void *));
-static void charshunt __P((int, int, char *));
-static int record_write __P((FILE *, int code, u_char *buf, int nb,
-			     struct timeval *));
-static int open_socket __P((char *));
-static void maybe_relock __P((void *, int));
+static int setdevname(char *, char **, int);
+static int setspeed(char *, char **, int);
+static int setxonxoff(char **);
+static int setescape(char **);
+static void printescape(option_t *, void (*)(void *, char *,...),void *);
+static void finish_tty(void);
+static int start_charshunt(int, int);
+static void stop_charshunt(void *, int);
+static void charshunt_done(void *);
+static void charshunt(int, int, char *);
+static int record_write(FILE *, int code, u_char *buf, int nb,
+			     struct timeval *);
+static int open_socket(char *);
+static void maybe_relock(void *, int);
 
 static int pty_master;		/* fd for master side of pty */
 static int pty_slave;		/* fd for slave side of pty */
@@ -377,7 +377,7 @@ setescape(argv)
 static void
 printescape(opt, printer, arg)
     option_t *opt;
-    void (*printer) __P((void *, char *, ...));
+    void (*printer)(void *, char *, ...);
     void *arg;
 {
 	int n;

--- a/pppd/upap.c
+++ b/pppd/upap.c
@@ -77,13 +77,13 @@ static option_t pap_option_list[] = {
 /*
  * Protocol entry points.
  */
-static void upap_init __P((int));
-static void upap_lowerup __P((int));
-static void upap_lowerdown __P((int));
-static void upap_input __P((int, u_char *, int));
-static void upap_protrej __P((int));
-static int  upap_printpkt __P((u_char *, int,
-			       void (*) __P((void *, char *, ...)), void *));
+static void upap_init(int);
+static void upap_lowerup(int);
+static void upap_lowerdown(int);
+static void upap_input(int, u_char *, int);
+static void upap_protrej(int);
+static int  upap_printpkt(u_char *, int,
+			       void (*)(void *, char *, ...), void *);
 
 struct protent pap_protent = {
     PPP_PAP,
@@ -107,13 +107,13 @@ struct protent pap_protent = {
 
 upap_state upap[NUM_PPP];		/* UPAP state; one for each unit */
 
-static void upap_timeout __P((void *));
-static void upap_reqtimeout __P((void *));
-static void upap_rauthreq __P((upap_state *, u_char *, int, int));
-static void upap_rauthack __P((upap_state *, u_char *, int, int));
-static void upap_rauthnak __P((upap_state *, u_char *, int, int));
-static void upap_sauthreq __P((upap_state *));
-static void upap_sresp __P((upap_state *, int, int, char *, int));
+static void upap_timeout(void *);
+static void upap_reqtimeout(void *);
+static void upap_rauthreq(upap_state *, u_char *, int, int);
+static void upap_rauthack(upap_state *, u_char *, int, int);
+static void upap_rauthnak(upap_state *, u_char *, int, int);
+static void upap_sauthreq(upap_state *);
+static void upap_sresp(upap_state *, int, int, char *, int);
 
 
 /*
@@ -611,7 +611,7 @@ static int
 upap_printpkt(p, plen, printer, arg)
     u_char *p;
     int plen;
-    void (*printer) __P((void *, char *, ...));
+    void (*printer)(void *, char *, ...);
     void *arg;
 {
     int code, id, len;

--- a/pppd/upap.h
+++ b/pppd/upap.h
@@ -104,7 +104,7 @@ typedef struct upap_state {
 
 extern upap_state upap[];
 
-void upap_authwithpeer __P((int, char *, char *));
-void upap_authpeer __P((int));
+void upap_authwithpeer(int, char *, char *);
+void upap_authpeer(int);
 
 extern struct protent pap_protent;

--- a/pppd/utils.c
+++ b/pppd/utils.c
@@ -64,10 +64,10 @@
 extern char *strerror();
 #endif
 
-static void logit __P((int, char *, va_list));
-static void log_write __P((int, char *));
-static void vslp_printer __P((void *, char *, ...));
-static void format_packet __P((u_char *, int, printer_func, void *));
+static void logit(int, char *, va_list);
+static void log_write(int, char *);
+static void vslp_printer(void *, char *, ...);
+static void format_packet(u_char *, int, printer_func, void *);
 
 struct buffer_info {
     char *ptr;

--- a/pppdump/bsd-comp.c
+++ b/pppdump/bsd-comp.c
@@ -124,15 +124,15 @@ struct bsd_db {
 #define BSD_OVHD	2		/* BSD compress overhead/packet */
 #define BSD_INIT_BITS	BSD_MIN_BITS
 
-static void	*bsd_decomp_alloc __P((u_char *options, int opt_len));
-static void	bsd_free __P((void *state));
-static int	bsd_decomp_init __P((void *state, u_char *options, int opt_len,
-				     int unit, int hdrlen, int mru, int debug));
-static void	bsd_incomp __P((void *state, u_char *dmsg, int len));
-static int	bsd_decompress __P((void *state, u_char *cmp, int inlen,
-				    u_char *dmp, int *outlen));
-static void	bsd_reset __P((void *state));
-static void	bsd_comp_stats __P((void *state, struct compstat *stats));
+static void	*bsd_decomp_alloc(u_char *options, int opt_len);
+static void	bsd_free(void *state);
+static int	bsd_decomp_init(void *state, u_char *options, int opt_len,
+				     int unit, int hdrlen, int mru, int debug);
+static void	bsd_incomp(void *state, u_char *dmsg, int len);
+static int	bsd_decompress(void *state, u_char *cmp, int inlen,
+				    u_char *dmp, int *outlen);
+static void	bsd_reset(void *state);
+static void	bsd_comp_stats(void *state, struct compstat *stats);
 
 /*
  * Exported procedures.

--- a/pppdump/deflate.c
+++ b/pppdump/deflate.c
@@ -65,17 +65,17 @@ struct deflate_state {
 
 #define DEFLATE_OVHD	2		/* Deflate overhead/packet */
 
-static void	*z_alloc __P((void *, u_int items, u_int size));
-static void	z_free __P((void *, void *ptr, u_int nb));
-static void	*z_decomp_alloc __P((u_char *options, int opt_len));
-static void	z_decomp_free __P((void *state));
-static int	z_decomp_init __P((void *state, u_char *options, int opt_len,
-				     int unit, int hdrlen, int mru, int debug));
-static void	z_incomp __P((void *state, u_char *dmsg, int len));
-static int	z_decompress __P((void *state, u_char *cmp, int inlen,
-				    u_char *dmp, int *outlenp));
-static void	z_decomp_reset __P((void *state));
-static void	z_comp_stats __P((void *state, struct compstat *stats));
+static void	*z_alloc(void *, u_int items, u_int size);
+static void	z_free(void *, void *ptr, u_int nb);
+static void	*z_decomp_alloc(u_char *options, int opt_len);
+static void	z_decomp_free(void *state);
+static int	z_decomp_init(void *state, u_char *options, int opt_len,
+				     int unit, int hdrlen, int mru, int debug);
+static void	z_incomp(void *state, u_char *dmsg, int len);
+static int	z_decompress(void *state, u_char *cmp, int inlen,
+				    u_char *dmp, int *outlenp);
+static void	z_decomp_reset(void *state);
+static void	z_comp_stats(void *state, struct compstat *stats);
 
 /*
  * Procedures exported to if_ppp.c.

--- a/pppdump/ppp-comp.h
+++ b/pppdump/ppp-comp.h
@@ -58,21 +58,21 @@ struct compressor {
 	int	compress_proto;	/* CCP compression protocol number */
 
 	/* Allocate space for a decompressor (receive side) */
-	void	*(*decomp_alloc) __P((u_char *options, int opt_len));
+	void	*(*decomp_alloc)(u_char *options, int opt_len);
 	/* Free space used by a decompressor */
-	void	(*decomp_free) __P((void *state));
+	void	(*decomp_free)(void *state);
 	/* Initialize a decompressor */
-	int	(*decomp_init) __P((void *state, u_char *options, int opt_len,
-				    int unit, int hdrlen, int mru, int debug));
+	int	(*decomp_init)(void *state, u_char *options, int opt_len,
+				    int unit, int hdrlen, int mru, int debug);
 	/* Reset a decompressor */
-	void	(*decomp_reset) __P((void *state));
+	void	(*decomp_reset)(void *state);
 	/* Decompress a packet. */
-	int	(*decompress) __P((void *state, u_char *mp, int inlen,
-				   u_char *dmp, int *outlen));
+	int	(*decompress)(void *state, u_char *mp, int inlen,
+				   u_char *dmp, int *outlen);
 	/* Update state for an incompressible packet received */
-	void	(*incomp) __P((void *state, u_char *mp, int len));
+	void	(*incomp)(void *state, u_char *mp, int len);
 	/* Return decompression statistics */
-	void	(*decomp_stat) __P((void *state, struct compstat *stats));
+	void	(*decomp_stat)(void *state, struct compstat *stats);
 };
 
 /*

--- a/pppstats/pppstats.c
+++ b/pppstats/pppstats.c
@@ -106,13 +106,13 @@ extern char *optarg;
 #define PPP_DRV_NAME    "ppp"
 #endif /* !defined(PPP_DRV_NAME) */
 
-static void usage __P((void));
-static void catchalarm __P((int));
-static void get_ppp_stats __P((struct ppp_stats *));
-static void get_ppp_cstats __P((struct ppp_comp_stats *));
-static void intpr __P((void));
+static void usage(void);
+static void catchalarm(int);
+static void get_ppp_stats(struct ppp_stats *);
+static void get_ppp_cstats(struct ppp_comp_stats *);
+static void intpr(void);
 
-int main __P((int, char *argv[]));
+int main(int, char *argv[]);
 
 static void
 usage()

--- a/solaris/ppp.c
+++ b/solaris/ppp.c
@@ -85,12 +85,6 @@
 
 #include <netinet/in.h>	/* leave this outside of PRIOQ for htons */
 
-#ifdef __STDC__
-#define __P(x)	x
-#else
-#define __P(x)	()
-#endif
-
 /*
  * The IP module may use this SAP value for IP packets.
  */
@@ -254,45 +248,45 @@ static upperstr_t *minor_devs = NULL;
 static upperstr_t *ppas = NULL;
 
 #ifdef SVR4
-static int pppopen __P((queue_t *, dev_t *, int, int, cred_t *));
-static int pppclose __P((queue_t *, int, cred_t *));
+static int pppopen(queue_t *, dev_t *, int, int, cred_t *);
+static int pppclose(queue_t *, int, cred_t *);
 #else
-static int pppopen __P((queue_t *, int, int, int));
-static int pppclose __P((queue_t *, int));
+static int pppopen(queue_t *, int, int, int);
+static int pppclose(queue_t *, int);
 #endif /* SVR4 */
-static int pppurput __P((queue_t *, mblk_t *));
-static int pppuwput __P((queue_t *, mblk_t *));
-static int pppursrv __P((queue_t *));
-static int pppuwsrv __P((queue_t *));
-static int ppplrput __P((queue_t *, mblk_t *));
-static int ppplwput __P((queue_t *, mblk_t *));
-static int ppplrsrv __P((queue_t *));
-static int ppplwsrv __P((queue_t *));
+static int pppurput(queue_t *, mblk_t *);
+static int pppuwput(queue_t *, mblk_t *);
+static int pppursrv(queue_t *);
+static int pppuwsrv(queue_t *);
+static int ppplrput(queue_t *, mblk_t *);
+static int ppplwput(queue_t *, mblk_t *);
+static int ppplrsrv(queue_t *);
+static int ppplwsrv(queue_t *);
 #ifndef NO_DLPI
-static void dlpi_request __P((queue_t *, mblk_t *, upperstr_t *));
-static void dlpi_error __P((queue_t *, upperstr_t *, int, int, int));
-static void dlpi_ok __P((queue_t *, int));
+static void dlpi_request(queue_t *, mblk_t *, upperstr_t *);
+static void dlpi_error(queue_t *, upperstr_t *, int, int, int);
+static void dlpi_ok(queue_t *, int);
 #endif
-static int send_data __P((mblk_t *, upperstr_t *));
-static void new_ppa __P((queue_t *, mblk_t *));
-static void attach_ppa __P((queue_t *, mblk_t *));
+static int send_data(mblk_t *, upperstr_t *);
+static void new_ppa(queue_t *, mblk_t *);
+static void attach_ppa(queue_t *, mblk_t *);
 #ifndef NO_DLPI
-static void detach_ppa __P((queue_t *, mblk_t *));
+static void detach_ppa(queue_t *, mblk_t *);
 #endif
-static void detach_lower __P((queue_t *, mblk_t *));
-static void debug_dump __P((queue_t *, mblk_t *));
-static upperstr_t *find_dest __P((upperstr_t *, int));
+static void detach_lower(queue_t *, mblk_t *);
+static void debug_dump(queue_t *, mblk_t *);
+static upperstr_t *find_dest(upperstr_t *, int);
 #if defined(SOL2)
-static upperstr_t *find_promisc __P((upperstr_t *, int));
-static mblk_t *prepend_ether __P((upperstr_t *, mblk_t *, int));
-static mblk_t *prepend_udind __P((upperstr_t *, mblk_t *, int));
-static void promisc_sendup __P((upperstr_t *, mblk_t *, int, int));
+static upperstr_t *find_promisc(upperstr_t *, int);
+static mblk_t *prepend_ether(upperstr_t *, mblk_t *, int);
+static mblk_t *prepend_udind(upperstr_t *, mblk_t *, int);
+static void promisc_sendup(upperstr_t *, mblk_t *, int, int);
 #endif /* defined(SOL2) */
-static int putctl2 __P((queue_t *, int, int, int));
-static int putctl4 __P((queue_t *, int, int, int));
-static int pass_packet __P((upperstr_t *ppa, mblk_t *mp, int outbound));
+static int putctl2(queue_t *, int, int, int);
+static int putctl4(queue_t *, int, int, int);
+static int pass_packet(upperstr_t *ppa, mblk_t *mp, int outbound);
 #ifdef FILTER_PACKETS
-static int ip_hard_filter __P((upperstr_t *ppa, mblk_t *mp, int outbound));
+static int ip_hard_filter(upperstr_t *ppa, mblk_t *mp, int outbound);
 #endif /* FILTER_PACKETS */
 
 #define PPP_ID 0xb1a6

--- a/solaris/ppp_ahdlc.c
+++ b/solaris/ppp_ahdlc.c
@@ -109,11 +109,11 @@ typedef unsigned int            uintpointer_t;
 
 MOD_OPEN_DECL(ahdlc_open);
 MOD_CLOSE_DECL(ahdlc_close);
-static int ahdlc_wput __P((queue_t *, mblk_t *));
-static int ahdlc_rput __P((queue_t *, mblk_t *));
-static void ahdlc_encode __P((queue_t *, mblk_t *));
-static void ahdlc_decode __P((queue_t *, mblk_t *));
-static int msg_byte __P((mblk_t *, unsigned int));
+static int ahdlc_wput(queue_t *, mblk_t *);
+static int ahdlc_rput(queue_t *, mblk_t *);
+static void ahdlc_encode(queue_t *, mblk_t *);
+static void ahdlc_decode(queue_t *, mblk_t *);
+static int msg_byte(mblk_t *, unsigned int);
 
 #if defined(SOL2)
 /*

--- a/solaris/ppp_comp.c
+++ b/solaris/ppp_comp.c
@@ -74,12 +74,12 @@
 
 MOD_OPEN_DECL(ppp_comp_open);
 MOD_CLOSE_DECL(ppp_comp_close);
-static int ppp_comp_rput __P((queue_t *, mblk_t *));
-static int ppp_comp_rsrv __P((queue_t *));
-static int ppp_comp_wput __P((queue_t *, mblk_t *));
-static int ppp_comp_wsrv __P((queue_t *));
-static void ppp_comp_ccp __P((queue_t *, mblk_t *, int));
-static int msg_byte __P((mblk_t *, unsigned int));
+static int ppp_comp_rput(queue_t *, mblk_t *);
+static int ppp_comp_rsrv(queue_t *);
+static int ppp_comp_wput(queue_t *, mblk_t *);
+static int ppp_comp_wsrv(queue_t *);
+static void ppp_comp_ccp(queue_t *, mblk_t *, int);
+static int msg_byte(mblk_t *, unsigned int);
 
 /* Extract byte i of message mp. */
 #define MSG_BYTE(mp, i)	((i) < (mp)->b_wptr - (mp)->b_rptr? (mp)->b_rptr[i]: \
@@ -118,7 +118,7 @@ int ppp_comp_count;		/* number of module instances in use */
 
 #ifdef __osf__
 
-static void ppp_comp_alloc __P((comp_state_t *));
+static void ppp_comp_alloc(comp_state_t *);
 typedef struct memreq {
     unsigned char comp_opts[20];
     int cmd;

--- a/solaris/ppp_mod.c
+++ b/solaris/ppp_mod.c
@@ -47,16 +47,10 @@
 #include <sys/sunddi.h>
 #include <sys/ksynch.h>
 
-#ifdef __STDC__
-#define __P(x)	x
-#else
-#define __P(x)	()
-#endif
-
-static int ppp_identify __P((dev_info_t *));
-static int ppp_attach __P((dev_info_t *, ddi_attach_cmd_t));
-static int ppp_detach __P((dev_info_t *, ddi_detach_cmd_t));
-static int ppp_devinfo __P((dev_info_t *, ddi_info_cmd_t, void *, void **));
+static int ppp_identify(dev_info_t *);
+static int ppp_attach(dev_info_t *, ddi_attach_cmd_t);
+static int ppp_detach(dev_info_t *, ddi_detach_cmd_t);
+static int ppp_devinfo(dev_info_t *, ddi_info_cmd_t, void *, void **);
 
 extern struct streamtab pppinfo;
 extern krwlock_t ppp_lower_lock;

--- a/solaris/ppp_mod.h
+++ b/solaris/ppp_mod.h
@@ -143,10 +143,10 @@ typedef int minor_t;
  */
 #ifdef SVR4
 #define MOD_OPEN_DECL(name)	\
-static int name __P((queue_t *, dev_t *, int, int, cred_t *))
+static int name(queue_t *, dev_t *, int, int, cred_t *)
 
 #define MOD_CLOSE_DECL(name)	\
-static int name __P((queue_t *, int, cred_t *))
+static int name(queue_t *, int, cred_t *)
 
 #define MOD_OPEN(name)				\
 static int name(q, devp, flag, sflag, credp)	\
@@ -168,10 +168,10 @@ static int name(q, flag, credp)	\
 
 #else	/* not SVR4 */
 #define MOD_OPEN_DECL(name)	\
-static int name __P((queue_t *, int, int, int))
+static int name(queue_t *, int, int, int)
 
 #define MOD_CLOSE_DECL(name)	\
-static int name __P((queue_t *, int))
+static int name(queue_t *, int)
 
 #define MOD_OPEN(name)		\
 static int name(q, dev, flag, sflag)	\


### PR DESCRIPTION
__P is normally defined in sys/cdefs.h , which musl does not have.

Signed-off-by: Rosen Penev <rosenp@gmail.com>