### PR TITLE
pppd: Do not call update_link_stats() for every LcpSendEchoRequest() call

### DIFF
--- a/pppd/lcp.c
+++ b/pppd/lcp.c
@@ -2339,12 +2339,10 @@ LcpSendEchoRequest (f)
      */
     if (lcp_echo_adaptive) {
 	static unsigned int last_pkts_in = 0;
+	struct pppd_stats cur_stats;
 
-	update_link_stats(f->unit);
-	link_stats_valid = 0;
-
-	if (link_stats.pkts_in != last_pkts_in) {
-	    last_pkts_in = link_stats.pkts_in;
+	if (get_ppp_stats(f->unit, &cur_stats) && cur_stats.pkts_in != last_pkts_in) {
+	    last_pkts_in = cur_stats.pkts_in;
 	    return;
 	}
     }


### PR DESCRIPTION
Function update_link_stats() is doing more than reading number of received
bytes, e.g. it changes state of link_stats_valid.

This change replace update_link_stats() by get_ppp_stats() in
LcpSendEchoRequest() function to avoid any side effects.