### PR TITLE
pppd: Fix blank password usage

### DIFF
--- a/pppd/auth.c
+++ b/pppd/auth.c
@@ -1338,7 +1338,7 @@ auth_reset(unit)
     hadchap = -1;
     ao->neg_upap = !refuse_pap && (passwd[0] != 0 || get_pap_passwd(NULL));
     ao->neg_chap = (!refuse_chap || !refuse_mschap || !refuse_mschap_v2)
-	&& (passwd[0] != 0 ||
+	&& ((passwd[0] != 0 || explicit_passwd) ||
 	    (hadchap = have_chap_secret(user, (explicit_remote? remote_name:
 					       NULL), 0, NULL)));
     ao->neg_eap = !refuse_eap && (


### PR DESCRIPTION
If a password has been provided as "", CHAP authentication wouldn't
happen. A user providing a username/password, even if blank, should be
expecting authentication to occur with those set.

Added a check for explicit_passwd property, set on finding the password
argument, to allow CHAP authentication with a blank password.

Signed-off-by: Simon Tate <simon.tate@bt.com>