### PR TITLE
Enable IPv6 by default

### DIFF
--- a/pppd/ipv6cp.c
+++ b/pppd/ipv6cp.c
@@ -303,7 +303,7 @@ struct protent ipv6cp_protent = {
     ipv6cp_close,
     ipv6cp_printpkt,
     NULL,
-    0,
+    1,
     "IPV6CP",
     "IPV6",
     ipv6cp_option_list,


### PR DESCRIPTION
Now in year 2020 we should not have disabled IPv6 support by default.

So let both IPv4 and IPv6 enabled by default.