### PR TITLE
Fedora patches

### DIFF
--- a/chat/Makefile.linux
+++ b/chat/Makefile.linux
@@ -13,7 +13,7 @@ CDEFS=	$(CDEF1) $(CDEF2) $(CDEF3) $(CDEF4)
 COPTS=	-O2 -g -pipe
 CFLAGS=	$(COPTS) $(CDEFS)
 
-INSTALL= install
+INSTALL= install -p
 
 all:	chat
 

--- a/chat/Makefile.linux
+++ b/chat/Makefile.linux
@@ -13,6 +13,7 @@ CDEFS=	$(CDEF1) $(CDEF2) $(CDEF3) $(CDEF4)
 COPTS=	-O2 -g -pipe
 CFLAGS=	$(COPTS) $(CDEFS)
 
+STRIP_FLAG=-s
 INSTALL= install -p
 
 all:	chat
@@ -25,7 +26,7 @@ chat.o:	chat.c
 
 install: chat
 	mkdir -p $(BINDIR) $(MANDIR)
-	$(INSTALL) -s -c chat $(BINDIR)
+	$(INSTALL) $(STRIP_FLAG) -c chat $(BINDIR)
 	$(INSTALL) -c -m 644 chat.8 $(MANDIR)
 
 clean:

--- a/chat/chat.8
+++ b/chat/chat.8
@@ -200,7 +200,7 @@ The \fBSAY\fR directive allows the script to send strings to the user
 at the terminal via standard error.  If \fBchat\fR is being run by
 pppd, and pppd is running as a daemon (detached from its controlling
 terminal), standard error will normally be redirected to the file
-/etc/ppp/connect\-errors.
+/var/log/ppp/connect\-errors.
 .LP
 \fBSAY\fR strings must be enclosed in single or double quotes. If
 carriage return and line feed are needed in the string to be output,

--- a/contrib/pppgetpass/Makefile.linux
+++ b/contrib/pppgetpass/Makefile.linux
@@ -8,9 +8,9 @@ pppgetpass.gtk.o: pppgetpass.gtk.c
 	$(CC) $(CFLAGS) -c pppgetpass.gtk.c `pkg-config --cflags glib-2.0 gtk+-2.0`
 
 install: all
-	install -m 755 pppgetpass.sh /usr/bin/pppgetpass
-	install -m 4755 -o root -g root pppgetpass.vt /usr/bin/
-	install -m 755 -o root -g root pppgetpass.gtk /usr/X11/bin/
+	install -p -m 755 pppgetpass.sh /usr/bin/pppgetpass
+	install -p -m 4755 -o root -g root pppgetpass.vt /usr/bin/
+	install -p -m 755 -o root -g root pppgetpass.gtk /usr/X11/bin/
 
 clean:
 	rm -f *.o pppgetpass.gtk pppgetpass.vt core

--- a/linux/Makefile.top
+++ b/linux/Makefile.top
@@ -9,7 +9,7 @@ RUNDIR = $(DESTDIR)/var/run/ppp
 LOGDIR = $(DESTDIR)/var/log/ppp
 
 # uid 0 = root
-INSTALL= install
+INSTALL= install -p
 
 all:
 	cd chat; $(MAKE) $(MFLAGS) all

--- a/linux/Makefile.top
+++ b/linux/Makefile.top
@@ -5,6 +5,8 @@ BINDIR = $(DESTDIR)/sbin
 INCDIR = $(DESTDIR)/include
 MANDIR = $(DESTDIR)/share/man
 ETCDIR = $(INSTROOT)@SYSCONF@/ppp
+RUNDIR = $(DESTDIR)/var/run/ppp
+LOGDIR = $(DESTDIR)/var/log/ppp
 
 # uid 0 = root
 INSTALL= install
@@ -16,7 +18,7 @@ all:
 	cd pppstats; $(MAKE) $(MFLAGS) all
 	cd pppdump; $(MAKE) $(MFLAGS) all
 
-install: $(BINDIR) $(MANDIR)/man8 install-progs install-devel
+install: $(BINDIR) $(RUNDIR) $(LOGDIR) $(MANDIR)/man8 install-progs install-devel
 
 install-progs:
 	cd chat; $(MAKE) $(MFLAGS) install
@@ -47,6 +49,10 @@ $(BINDIR):
 $(MANDIR)/man8:
 	$(INSTALL) -d -m 755 $@
 $(ETCDIR):
+	$(INSTALL) -d -m 755 $@
+$(RUNDIR):
+	$(INSTALL) -d -m 755 $@
+$(LOGDIR):
 	$(INSTALL) -d -m 755 $@
 
 clean:

--- a/pppd/Makefile.linux
+++ b/pppd/Makefile.linux
@@ -110,8 +110,8 @@ endif
 
 # EAP SRP-SHA1
 ifdef USE_SRP
-CFLAGS	+= -DUSE_SRP -DOPENSSL -I/usr/local/ssl/include
-LIBS	+= -lsrp -L/usr/local/ssl/lib
+CFLAGS	+= -DUSE_SRP -DOPENSSL -I$(DESTDIR)/ssl/include
+LIBS	+= -lsrp -L$(DESTDIR)/ssl/lib
 NEEDCRYPTOLIB = y
 TARGETS	+= srp-entry
 EXTRAINSTALL = $(INSTALL) $(STRIP_FLAG) -c -m 555 srp-entry $(BINDIR)/srp-entry

--- a/pppd/Makefile.linux
+++ b/pppd/Makefile.linux
@@ -8,6 +8,7 @@ DESTDIR = $(INSTROOT)@DESTDIR@
 BINDIR = $(DESTDIR)/sbin
 MANDIR = $(DESTDIR)/share/man/man8
 INCDIR = $(DESTDIR)/include
+LIBDIR = $(DESTDIR)/lib/$(shell gcc -print-multi-os-directory 2> /dev/null)
 
 TARGETS = pppd
 
@@ -90,7 +91,7 @@ INCLUDE_DIRS= -I../include
 
 COMPILE_FLAGS= -DHAVE_PATHS_H -DIPX_CHANGE -DHAVE_MMAP
 
-CFLAGS= $(COPTS) $(COMPILE_FLAGS) $(INCLUDE_DIRS) '-DDESTDIR="@DESTDIR@"'
+CFLAGS= $(COPTS) -DLIBDIR=\""$(LIBDIR)"\" $(COMPILE_FLAGS) $(INCLUDE_DIRS) '-DDESTDIR="@DESTDIR@"'
 
 STRIP_FLAG=-s
 

--- a/pppd/Makefile.linux
+++ b/pppd/Makefile.linux
@@ -241,10 +241,10 @@ all: $(TARGETS)
 install: pppd
 	mkdir -p $(BINDIR) $(MANDIR)
 	$(EXTRAINSTALL)
-	$(INSTALL) $(STRIP_FLAG) -c -m 555 pppd $(BINDIR)/pppd
+	$(INSTALL) $(STRIP_FLAG) -c -m 755 pppd $(BINDIR)/pppd
 	if chgrp pppusers $(BINDIR)/pppd 2>/dev/null; then \
 	  chmod o-rx,u+s $(BINDIR)/pppd; fi
-	$(INSTALL) -c -m 444 pppd.8 $(MANDIR)
+	$(INSTALL) -c -m 644 pppd.8 $(MANDIR)
 
 pppd: $(PPPDOBJS)
 	$(CC) $(CFLAGS) $(LDFLAGS) $(LDFLAGS_PLUGIN) -o pppd $(PPPDOBJS) $(LIBS)

--- a/pppd/Makefile.linux
+++ b/pppd/Makefile.linux
@@ -92,6 +92,8 @@ COMPILE_FLAGS= -DHAVE_PATHS_H -DIPX_CHANGE -DHAVE_MMAP
 
 CFLAGS= $(COPTS) $(COMPILE_FLAGS) $(INCLUDE_DIRS) '-DDESTDIR="@DESTDIR@"'
 
+STRIP_FLAG=-s
+
 ifdef CHAPMS
 CFLAGS   += -DCHAPMS=1
 NEEDDES=y
@@ -112,7 +114,7 @@ CFLAGS	+= -DUSE_SRP -DOPENSSL -I/usr/local/ssl/include
 LIBS	+= -lsrp -L/usr/local/ssl/lib
 NEEDCRYPTOLIB = y
 TARGETS	+= srp-entry
-EXTRAINSTALL = $(INSTALL) -s -c -m 555 srp-entry $(BINDIR)/srp-entry
+EXTRAINSTALL = $(INSTALL) $(STRIP_FLAG) -c -m 555 srp-entry $(BINDIR)/srp-entry
 MANPAGES += srp-entry.8
 EXTRACLEAN += srp-entry.o
 NEEDDES=y
@@ -238,7 +240,7 @@ all: $(TARGETS)
 install: pppd
 	mkdir -p $(BINDIR) $(MANDIR)
 	$(EXTRAINSTALL)
-	$(INSTALL) -s -c -m 555 pppd $(BINDIR)/pppd
+	$(INSTALL) $(STRIP_FLAG) -c -m 555 pppd $(BINDIR)/pppd
 	if chgrp pppusers $(BINDIR)/pppd 2>/dev/null; then \
 	  chmod o-rx,u+s $(BINDIR)/pppd; fi
 	$(INSTALL) -c -m 444 pppd.8 $(MANDIR)

--- a/pppd/Makefile.linux
+++ b/pppd/Makefile.linux
@@ -231,7 +231,7 @@ ifdef MAXOCTETS
      CFLAGS += -DMAXOCTETS
 endif
 
-INSTALL= install
+INSTALL= install -p
 
 all: $(TARGETS)
 

--- a/pppd/Makefile.linux
+++ b/pppd/Makefile.linux
@@ -31,7 +31,7 @@ ifeq (.depend,$(wildcard .depend))
 include .depend
 endif
 
-# CC = gcc
+CC = gcc
 #
 COPTS = -O2 -pipe -Wall -g
 LIBS = -lrt

--- a/pppd/Makefile.linux
+++ b/pppd/Makefile.linux
@@ -34,7 +34,7 @@ endif
 CC = gcc
 #
 COPTS = -O2 -pipe -Wall -g
-LIBS = -lrt
+LIBS = -lrt -ludev
 
 # Uncomment the next line to include support for Microsoft's
 # MS-CHAP authentication protocol.  Also, edit plugins/radius/Makefile.linux.

--- a/pppd/auth.c
+++ b/pppd/auth.c
@@ -476,7 +476,7 @@ setupapfile(argv)
         free(fname);
 	return 0;
     }
-    ufile = fopen(fname, "r");
+    ufile = fopen(fname, "re");
     if (seteuid(euid) == -1)
 	fatal("unable to regain privileges: %m");
     if (ufile == NULL) {
@@ -1508,7 +1508,7 @@ check_passwd(unit, auser, userlen, apasswd, passwdlen, msg)
     filename = _PATH_UPAPFILE;
     addrs = opts = NULL;
     ret = UPAP_AUTHNAK;
-    f = fopen(filename, "r");
+    f = fopen(filename, "re");
     if (f == NULL) {
 	error("Can't open PAP password file %s: %m", filename);
 
@@ -1607,7 +1607,7 @@ null_login(unit)
     if (ret <= 0) {
 	filename = _PATH_UPAPFILE;
 	addrs = NULL;
-	f = fopen(filename, "r");
+	f = fopen(filename, "re");
 	if (f == NULL)
 	    return 0;
 	check_access(f, filename);
@@ -1654,7 +1654,7 @@ get_pap_passwd(passwd)
     }
 
     filename = _PATH_UPAPFILE;
-    f = fopen(filename, "r");
+    f = fopen(filename, "re");
     if (f == NULL)
 	return 0;
     check_access(f, filename);
@@ -1692,7 +1692,7 @@ have_pap_secret(lacks_ipp)
     }
 
     filename = _PATH_UPAPFILE;
-    f = fopen(filename, "r");
+    f = fopen(filename, "re");
     if (f == NULL)
 	return 0;
 
@@ -1737,7 +1737,7 @@ have_chap_secret(client, server, need_ip, lacks_ipp)
     }
 
     filename = _PATH_CHAPFILE;
-    f = fopen(filename, "r");
+    f = fopen(filename, "re");
     if (f == NULL)
 	return 0;
 
@@ -1779,7 +1779,7 @@ have_srp_secret(client, server, need_ip, lacks_ipp)
     struct wordlist *addrs;
 
     filename = _PATH_SRPFILE;
-    f = fopen(filename, "r");
+    f = fopen(filename, "re");
     if (f == NULL)
 	return 0;
 
@@ -1835,7 +1835,7 @@ get_secret(unit, client, server, secret, secret_len, am_server)
 	addrs = NULL;
 	secbuf[0] = 0;
 
-	f = fopen(filename, "r");
+	f = fopen(filename, "re");
 	if (f == NULL) {
 	    error("Can't open chap secret file %s: %m", filename);
 	    return 0;
@@ -1892,7 +1892,7 @@ get_srp_secret(unit, client, server, secret, am_server)
 	filename = _PATH_SRPFILE;
 	addrs = NULL;
 
-	fp = fopen(filename, "r");
+	fp = fopen(filename, "re");
 	if (fp == NULL) {
 	    error("Can't open srp secret file %s: %m", filename);
 	    return 0;
@@ -2298,7 +2298,7 @@ scan_authfile(f, client, server, secret, addrs, opts, filename, flags)
 	     */
 	    if (word[0] == '@' && word[1] == '/') {
 		strlcpy(atfile, word+1, sizeof(atfile));
-		if ((sf = fopen(atfile, "r")) == NULL) {
+		if ((sf = fopen(atfile, "re")) == NULL) {
 		    warn("can't open indirect secret file %s", atfile);
 		    continue;
 		}

--- a/pppd/eap.c
+++ b/pppd/eap.c
@@ -1463,7 +1463,7 @@ mode_t modebits;
 
 	if ((path = name_of_pn_file()) == NULL)
 		return (-1);
-	fd = open(path, modebits, S_IRUSR | S_IWUSR);
+	fd = open(path, modebits, S_IRUSR | S_IWUSR | O_CLOEXEC);
 	err = errno;
 	free(path);
 	errno = err;

--- a/pppd/main.c
+++ b/pppd/main.c
@@ -410,7 +410,7 @@ main(argc, argv)
 	die(0);
 
     /* Make sure fds 0, 1, 2 are open to somewhere. */
-    fd_devnull = open(_PATH_DEVNULL, O_RDWR);
+    fd_devnull = open(_PATH_DEVNULL, O_RDWR | O_CLOEXEC);
     if (fd_devnull < 0)
 	fatal("Couldn't open %s: %m", _PATH_DEVNULL);
     while (fd_devnull <= 2) {
@@ -1687,7 +1687,7 @@ device_script(program, in, out, dont_wait)
     if (log_to_fd >= 0)
 	errfd = log_to_fd;
     else
-	errfd = open(_PATH_CONNERRS, O_WRONLY | O_APPEND | O_CREAT, 0600);
+	errfd = open(_PATH_CONNERRS, O_WRONLY | O_APPEND | O_CREAT | O_CLOEXEC, 0600);
 
     ++conn_running;
     pid = safe_fork(in, out, errfd);

--- a/pppd/multilink.c
+++ b/pppd/multilink.c
@@ -436,12 +436,12 @@ static int
 get_default_epdisc(ep)
      struct epdisc *ep;
 {
-	char *p;
+	char *p = NULL;
 	struct hostent *hp;
 	u_int32_t addr;
 
 	/* First try for an ethernet MAC address */
-	p = get_first_ethernet();
+        get_first_ethernet(&p);
 	if (p != 0 && get_if_hwaddr(ep->value, p) >= 0) {
 		ep->class = EPD_MAC;
 		ep->length = 6;

--- a/pppd/options.c
+++ b/pppd/options.c
@@ -444,7 +444,7 @@ options_from_file(filename, must_exist, check_prot, priv)
 	option_error("unable to drop privileges to open %s: %m", filename);
 	return 0;
     }
-    f = fopen(filename, "r");
+    f = fopen(filename, "re");
     err = errno;
     if (check_prot && seteuid(euid) == -1)
 	fatal("unable to regain privileges");

--- a/pppd/options.c
+++ b/pppd/options.c
@@ -1572,9 +1572,9 @@ setlogfile(argv)
 	option_error("unable to drop permissions to open %s: %m", *argv);
 	return 0;
     }
-    fd = open(*argv, O_WRONLY | O_APPEND | O_CREAT | O_EXCL, 0644);
+    fd = open(*argv, O_WRONLY | O_APPEND | O_CREAT | O_EXCL | O_CLOEXEC, 0644);
     if (fd < 0 && errno == EEXIST)
-	fd = open(*argv, O_WRONLY | O_APPEND);
+	fd = open(*argv, O_WRONLY | O_APPEND | O_CLOEXEC);
     err = errno;
     if (!privileged_option && seteuid(euid) == -1)
 	fatal("unable to regain privileges: %m");

--- a/pppd/pathnames.h
+++ b/pppd/pathnames.h
@@ -61,7 +61,7 @@
 
 #ifdef PLUGIN
 #ifdef __STDC__
-#define _PATH_PLUGIN	DESTDIR "/lib/pppd/" VERSION
+#define _PATH_PLUGIN	LIBDIR "/pppd/" VERSION
 #else /* __STDC__ */
 #define _PATH_PLUGIN	"/usr/lib/pppd"
 #endif /* __STDC__ */

--- a/pppd/pathnames.h
+++ b/pppd/pathnames.h
@@ -6,8 +6,9 @@
 
 #ifdef HAVE_PATHS_H
 #include <paths.h>
-
+#define _PPP_SUBDIR	"ppp/"
 #else /* HAVE_PATHS_H */
+#define _PPP_SUBDIR
 #ifndef _PATH_VARRUN
 #define _PATH_VARRUN 	"/etc/ppp/"
 #endif
@@ -53,13 +54,9 @@
 #endif /* IPX_CHANGE */
 
 #ifdef __STDC__
-#define _PATH_PPPDB	_ROOT_PATH _PATH_VARRUN "pppd2.tdb"
+#define _PATH_PPPDB	_ROOT_PATH _PATH_VARRUN _PPP_SUBDIR "pppd2.tdb"
 #else /* __STDC__ */
-#ifdef HAVE_PATHS_H
-#define _PATH_PPPDB	"/var/run/pppd2.tdb"
-#else
-#define _PATH_PPPDB	"/etc/ppp/pppd2.tdb"
-#endif
+#define _PATH_PPPDB	_PATH_VARRUN _PPP_SUBDIR "pppd2.tdb"
 #endif /* __STDC__ */
 
 #ifdef PLUGIN

--- a/pppd/pathnames.h
+++ b/pppd/pathnames.h
@@ -35,9 +35,9 @@
 #define _PATH_AUTHUP	 _ROOT_PATH "/etc/ppp/auth-up"
 #define _PATH_AUTHDOWN	 _ROOT_PATH "/etc/ppp/auth-down"
 #define _PATH_TTYOPT	 _ROOT_PATH "/etc/ppp/options."
-#define _PATH_CONNERRS	 _ROOT_PATH "/etc/ppp/connect-errors"
+#define _PATH_CONNERRS	 _ROOT_PATH "/var/log/ppp/connect-errors"
 #define _PATH_PEERFILES	 _ROOT_PATH "/etc/ppp/peers/"
-#define _PATH_RESOLV	 _ROOT_PATH "/etc/ppp/resolv.conf"
+#define _PATH_RESOLV	 _ROOT_PATH "/var/run/ppp/resolv.conf"
 
 #define _PATH_USEROPT	 ".ppprc"
 #define	_PATH_PSEUDONYM	 ".ppp_pseudonym"

--- a/pppd/plugins/Makefile.linux
+++ b/pppd/plugins/Makefile.linux
@@ -10,7 +10,7 @@ CFLAGS += -DUSE_EAPTLS=1
 DESTDIR = $(INSTROOT)@DESTDIR@
 BINDIR = $(DESTDIR)/sbin
 MANDIR = $(DESTDIR)/share/man/man8
-LIBDIR = $(DESTDIR)/lib/pppd/$(VERSION)
+LIBDIR = $(DESTDIR)/lib/$(shell $(CC) -print-multi-os-directory 2> /dev/null)/pppd/$(VERSION)
 
 SUBDIRS := rp-pppoe pppoatm pppol2tp
 # Uncomment the next line to include the radius authentication plugin

--- a/pppd/plugins/Makefile.linux
+++ b/pppd/plugins/Makefile.linux
@@ -2,7 +2,7 @@
 COPTS	= -O2 -g
 CFLAGS	= $(COPTS) -I.. -I../../include -fPIC
 LDFLAGS_SHARED	= -shared
-INSTALL	= install
+INSTALL	= install -p
 
 # EAP-TLS
 CFLAGS += -DUSE_EAPTLS=1

--- a/pppd/plugins/pppoatm/Makefile.linux
+++ b/pppd/plugins/pppoatm/Makefile.linux
@@ -37,7 +37,7 @@ $(PLUGIN): $(PLUGIN_OBJS)
 
 install: all
 	$(INSTALL) -d -m 755 $(LIBDIR)
-	$(INSTALL) -c -m 4550 $(PLUGIN) $(LIBDIR)
+	$(INSTALL) -c -m 755 $(PLUGIN) $(LIBDIR)
 
 clean:
 	rm -f *.o *.so

--- a/pppd/plugins/pppoatm/Makefile.linux
+++ b/pppd/plugins/pppoatm/Makefile.linux
@@ -7,7 +7,7 @@ INSTALL	= install -p
 #***********************************************************************
 
 DESTDIR = $(INSTROOT)@DESTDIR@
-LIBDIR = $(DESTDIR)/lib/pppd/$(VERSION)
+LIBDIR = $(DESTDIR)/lib/$(shell gcc -print-multi-os-directory 2> /dev/null)/pppd/$(VERSION)
 
 VERSION = $(shell awk -F '"' '/VERSION/ { print $$2; }' ../../patchlevel.h)
 

--- a/pppd/plugins/pppoatm/Makefile.linux
+++ b/pppd/plugins/pppoatm/Makefile.linux
@@ -2,7 +2,7 @@
 COPTS	= -O2 -g
 CFLAGS	= $(COPTS) -I../.. -I../../../include -fPIC
 LDFLAGS_SHARED	= -shared
-INSTALL	= install
+INSTALL	= install -p
 
 #***********************************************************************
 

--- a/pppd/plugins/pppoatm/pppoatm.c
+++ b/pppd/plugins/pppoatm/pppoatm.c
@@ -135,7 +135,7 @@ static int connect_pppoatm(void)
 
 	if (!device_got_set)
 		no_device_given_pppoatm();
-	fd = socket(AF_ATMPVC, SOCK_DGRAM, 0);
+	fd = socket(AF_ATMPVC, SOCK_DGRAM | SOCK_CLOEXEC, 0);
 	if (fd < 0)
 		fatal("failed to create socket: %m");
 	memset(&qos, 0, sizeof qos);

--- a/pppd/plugins/pppol2tp/Makefile.linux
+++ b/pppd/plugins/pppol2tp/Makefile.linux
@@ -6,8 +6,8 @@ INSTALL	= install -p
 
 #***********************************************************************
 
-DESTDIR = @DESTDIR@
-LIBDIR = $(DESTDIR)/lib/pppd/$(VERSION)
+DESTDIR = $(INSTROOT)@DESTDIR@
+LIBDIR = $(DESTDIR)/lib/$(shell gcc -print-multi-os-directory 2> /dev/null)/pppd/$(VERSION)
 
 VERSION = $(shell awk -F '"' '/VERSION/ { print $$2; }' ../../patchlevel.h)
 

--- a/pppd/plugins/pppol2tp/Makefile.linux
+++ b/pppd/plugins/pppol2tp/Makefile.linux
@@ -2,7 +2,7 @@
 COPTS	= -O2 -g
 CFLAGS	= $(COPTS) -I. -I../.. -I../../../include -fPIC
 LDFLAGS_SHARED	= -shared
-INSTALL	= install
+INSTALL	= install -p
 
 #***********************************************************************
 

--- a/pppd/plugins/pppol2tp/openl2tp.c
+++ b/pppd/plugins/pppol2tp/openl2tp.c
@@ -83,7 +83,7 @@ static int openl2tp_client_create(void)
 	int result;
 
 	if (openl2tp_fd < 0) {
-		openl2tp_fd = socket(PF_UNIX, SOCK_DGRAM, 0);
+		openl2tp_fd = socket(PF_UNIX, SOCK_DGRAM | SOCK_CLOEXEC, 0);
 		if (openl2tp_fd < 0) {
 			error("openl2tp connection create: %m");
 			return -ENOTCONN;

--- a/pppd/plugins/pppol2tp/pppol2tp.c
+++ b/pppd/plugins/pppol2tp/pppol2tp.c
@@ -210,7 +210,7 @@ static void send_config_pppol2tp(int mtu,
 		struct ifreq ifr;
 		int fd;
 
-		fd = socket(AF_INET, SOCK_DGRAM, 0);
+		fd = socket(AF_INET, SOCK_DGRAM | SOCK_CLOEXEC, 0);
 		if (fd >= 0) {
 			memset (&ifr, '\0', sizeof (ifr));
 			strlcpy(ifr.ifr_name, ifname, sizeof(ifr.ifr_name));

--- a/pppd/plugins/radius/Makefile.linux
+++ b/pppd/plugins/radius/Makefile.linux
@@ -5,7 +5,7 @@
 
 DESTDIR = $(INSTROOT)@DESTDIR@
 MANDIR = $(DESTDIR)/share/man/man8
-LIBDIR = $(DESTDIR)/lib/pppd/$(VERSION)
+LIBDIR = $(DESTDIR)/lib/$(shell gcc -print-multi-os-directory 2> /dev/null)/pppd/$(VERSION)
 
 VERSION = $(shell awk -F '"' '/VERSION/ { print $$2; }' ../../patchlevel.h)
 

--- a/pppd/plugins/radius/Makefile.linux
+++ b/pppd/plugins/radius/Makefile.linux
@@ -9,7 +9,7 @@ LIBDIR = $(DESTDIR)/lib/pppd/$(VERSION)
 
 VERSION = $(shell awk -F '"' '/VERSION/ { print $$2; }' ../../patchlevel.h)
 
-INSTALL	= install
+INSTALL	= install -p
 
 PLUGIN=radius.so radattr.so radrealms.so
 CFLAGS=-I. -I../.. -I../../../include -O2 -fPIC -DRC_LOG_FACILITY=LOG_DAEMON

--- a/pppd/plugins/radius/Makefile.linux
+++ b/pppd/plugins/radius/Makefile.linux
@@ -9,6 +9,7 @@ LIBDIR = $(DESTDIR)/lib/pppd/$(VERSION)
 
 VERSION = $(shell awk -F '"' '/VERSION/ { print $$2; }' ../../patchlevel.h)
 
+STRIP_FLAG=-s
 INSTALL	= install -p
 
 PLUGIN=radius.so radattr.so radrealms.so
@@ -36,9 +37,9 @@ all: $(PLUGIN)
 
 install: all
 	$(INSTALL) -d -m 755 $(LIBDIR)
-	$(INSTALL) -s -c -m 755 radius.so $(LIBDIR)
-	$(INSTALL) -s -c -m 755 radattr.so $(LIBDIR)
-	$(INSTALL) -s -c -m 755 radrealms.so $(LIBDIR)
+	$(INSTALL) $(STRIP_FLAG) -c -m 755 radius.so $(LIBDIR)
+	$(INSTALL) $(STRIP_FLAG) -c -m 755 radattr.so $(LIBDIR)
+	$(INSTALL) $(STRIP_FLAG) -c -m 755 radrealms.so $(LIBDIR)
 	$(INSTALL) -c -m 444 pppd-radius.8 $(MANDIR)
 	$(INSTALL) -c -m 444 pppd-radattr.8 $(MANDIR)
 

--- a/pppd/plugins/radius/Makefile.linux
+++ b/pppd/plugins/radius/Makefile.linux
@@ -13,7 +13,8 @@ STRIP_FLAG=-s
 INSTALL	= install -p
 
 PLUGIN=radius.so radattr.so radrealms.so
-CFLAGS=-I. -I../.. -I../../../include -O2 -fPIC -DRC_LOG_FACILITY=LOG_DAEMON
+COPTS=-O2
+CFLAGS=-I. -I../.. -I../../../include $(COPTS) -fPIC -DRC_LOG_FACILITY=LOG_DAEMON
 
 # Uncomment the next line to include support for Microsoft's
 # MS-CHAP authentication protocol.

--- a/pppd/plugins/rp-pppoe/Makefile.linux
+++ b/pppd/plugins/rp-pppoe/Makefile.linux
@@ -16,7 +16,7 @@
 
 DESTDIR = $(INSTROOT)@DESTDIR@
 BINDIR = $(DESTDIR)/sbin
-LIBDIR = $(DESTDIR)/lib/pppd/$(PPPDVERSION)
+LIBDIR = $(DESTDIR)/lib/$(shell gcc -print-multi-os-directory 2> /dev/null)/pppd/$(PPPDVERSION)
 
 PPPDVERSION = $(shell awk -F '"' '/VERSION/ { print $$2; }' ../../patchlevel.h)
 

--- a/pppd/plugins/rp-pppoe/Makefile.linux
+++ b/pppd/plugins/rp-pppoe/Makefile.linux
@@ -44,9 +44,9 @@ rp-pppoe.so: plugin.o discovery.o if.o common.o
 
 install: all
 	$(INSTALL) -d -m 755 $(LIBDIR)
-	$(INSTALL) $(STRIP_FLAG) -c -m 4550 rp-pppoe.so $(LIBDIR)
+	$(INSTALL) $(STRIP_FLAG) -c -m 755 rp-pppoe.so $(LIBDIR)
 	$(INSTALL) -d -m 755 $(BINDIR)
-	$(INSTALL) $(STRIP_FLAG) -c -m 555 pppoe-discovery $(BINDIR)
+	$(INSTALL) $(STRIP_FLAG) -c -m 755 pppoe-discovery $(BINDIR)
 
 clean:
 	rm -f *.o *.so pppoe-discovery

--- a/pppd/plugins/rp-pppoe/Makefile.linux
+++ b/pppd/plugins/rp-pppoe/Makefile.linux
@@ -16,6 +16,7 @@
 
 DESTDIR = $(INSTROOT)@DESTDIR@
 BINDIR = $(DESTDIR)/sbin
+MANDIR = $(DESTDIR)/share/man/man8
 LIBDIR = $(DESTDIR)/lib/$(shell gcc -print-multi-os-directory 2> /dev/null)/pppd/$(PPPDVERSION)
 
 PPPDVERSION = $(shell awk -F '"' '/VERSION/ { print $$2; }' ../../patchlevel.h)
@@ -47,6 +48,7 @@ install: all
 	$(INSTALL) $(STRIP_FLAG) -c -m 755 rp-pppoe.so $(LIBDIR)
 	$(INSTALL) -d -m 755 $(BINDIR)
 	$(INSTALL) $(STRIP_FLAG) -c -m 755 pppoe-discovery $(BINDIR)
+	$(INSTALL) -c -m 644 pppoe-discovery.8 $(MANDIR)
 
 clean:
 	rm -f *.o *.so pppoe-discovery

--- a/pppd/plugins/rp-pppoe/Makefile.linux
+++ b/pppd/plugins/rp-pppoe/Makefile.linux
@@ -20,6 +20,7 @@ LIBDIR = $(DESTDIR)/lib/pppd/$(PPPDVERSION)
 
 PPPDVERSION = $(shell awk -F '"' '/VERSION/ { print $$2; }' ../../patchlevel.h)
 
+STRIP_FLAG=-s
 INSTALL	= install -p
 
 # Version is set ONLY IN THE MAKEFILE!  Don't delete this!
@@ -43,9 +44,9 @@ rp-pppoe.so: plugin.o discovery.o if.o common.o
 
 install: all
 	$(INSTALL) -d -m 755 $(LIBDIR)
-	$(INSTALL) -s -c -m 4550 rp-pppoe.so $(LIBDIR)
+	$(INSTALL) $(STRIP_FLAG) -c -m 4550 rp-pppoe.so $(LIBDIR)
 	$(INSTALL) -d -m 755 $(BINDIR)
-	$(INSTALL) -s -c -m 555 pppoe-discovery $(BINDIR)
+	$(INSTALL) $(STRIP_FLAG) -c -m 555 pppoe-discovery $(BINDIR)
 
 clean:
 	rm -f *.o *.so pppoe-discovery

--- a/pppd/plugins/rp-pppoe/Makefile.linux
+++ b/pppd/plugins/rp-pppoe/Makefile.linux
@@ -31,8 +31,8 @@ COPTS=-O2 -g
 CFLAGS=$(COPTS) -I../../../include '-DRP_VERSION="$(RP_VERSION)"'
 all: rp-pppoe.so pppoe-discovery
 
-pppoe-discovery: pppoe-discovery.o debug.o
-	$(CC) $(LDFLAGS) -o pppoe-discovery pppoe-discovery.o debug.o
+pppoe-discovery: pppoe-discovery.o debug.o common.o
+	$(CC) $(LDFLAGS) -o pppoe-discovery pppoe-discovery.o debug.o -ludev
 
 pppoe-discovery.o: pppoe-discovery.c
 	$(CC) $(CFLAGS) -I../../.. -c -o pppoe-discovery.o pppoe-discovery.c

--- a/pppd/plugins/rp-pppoe/Makefile.linux
+++ b/pppd/plugins/rp-pppoe/Makefile.linux
@@ -20,7 +20,7 @@ LIBDIR = $(DESTDIR)/lib/pppd/$(PPPDVERSION)
 
 PPPDVERSION = $(shell awk -F '"' '/VERSION/ { print $$2; }' ../../patchlevel.h)
 
-INSTALL	= install
+INSTALL	= install -p
 
 # Version is set ONLY IN THE MAKEFILE!  Don't delete this!
 RP_VERSION=3.8p

--- a/pppd/plugins/rp-pppoe/if.c
+++ b/pppd/plugins/rp-pppoe/if.c
@@ -116,7 +116,7 @@ openInterface(char const *ifname, UINT16_t type, unsigned char *hwaddr)
     stype = SOCK_PACKET;
 #endif
 
-    if ((fd = socket(domain, stype, htons(type))) < 0) {
+    if ((fd = socket(domain, stype | SOCK_CLOEXEC, htons(type))) < 0) {
 	/* Give a more helpful message for the common error case */
 	if (errno == EPERM) {
 	    fatal("Cannot create raw socket -- pppoe must be run as root.");

--- a/pppd/plugins/rp-pppoe/plugin.c
+++ b/pppd/plugins/rp-pppoe/plugin.c
@@ -146,7 +146,7 @@ PPPOEConnectDevice(void)
     /* server equipment).                                                  */
     /* Opening this socket just before waitForPADS in the discovery()      */
     /* function would be more appropriate, but it would mess-up the code   */
-    conn->sessionSocket = socket(AF_PPPOX, SOCK_STREAM, PX_PROTO_OE);
+    conn->sessionSocket = socket(AF_PPPOX, SOCK_STREAM | SOCK_CLOEXEC, PX_PROTO_OE);
     if (conn->sessionSocket < 0) {
 	error("Failed to create PPPoE socket: %m");
 	return -1;
@@ -157,7 +157,7 @@ PPPOEConnectDevice(void)
     lcp_wantoptions[0].mru = conn->mru;
 
     /* Update maximum MRU */
-    s = socket(AF_INET, SOCK_DGRAM, 0);
+    s = socket(AF_INET, SOCK_DGRAM | SOCK_CLOEXEC, 0);
     if (s < 0) {
 	error("Can't get MTU for %s: %m", conn->ifName);
 	goto errout;
@@ -343,7 +343,7 @@ PPPoEDevnameHook(char *cmd, char **argv, int doit)
     }
 
     /* Open a socket */
-    if ((fd = socket(PF_PACKET, SOCK_RAW, 0)) < 0) {
+    if ((fd = socket(PF_PACKET, SOCK_RAW | SOCK_CLOEXEC, 0)) < 0) {
 	r = 0;
     }
 

--- a/pppd/plugins/rp-pppoe/pppoe-discovery.8
+++ b/pppd/plugins/rp-pppoe/pppoe-discovery.8
@@ -1,0 +1,86 @@
+.\" pppoe-discovery.8 written by
+.\" Ben Hutchings <ben@decadentplace.org.uk>, based on pppoe.8.
+.\" Licenced under the GPL version 2 or later.
+.TH PPPOE-DISCOVERY 8
+.SH NAME
+pppoe\-discovery \- perform PPPoE discovery
+.SH SYNOPSIS
+.B pppoe\-discovery
+[
+.I options
+]
+.br
+.BR pppoe\-discovery " { " \-V " | " \-h " }"
+.SH DESCRIPTION
+.LP
+\fBpppoe\-discovery\fR performs the same discovery process as
+\fBpppoe\fR, but does not initiate a session.
+It sends a PADI packet and then prints the names of access
+concentrators in each PADO packet it receives.
+.SH OPTIONS
+.TP
+.BI \-I " interface"
+.RS
+The \fB\-I\fR option specifies the Ethernet interface to use.
+Under Linux, it is typically eth0 or eth1.
+The interface should be \(lqup\(rq before you start
+\fBpppoe\-discovery\fR, but should \fInot\fR be configured to have an
+IP address.
+The default interface is eth0.
+.RE
+.TP
+.BI \-D " file_name"
+.RS
+The \fB\-D\fR option causes every packet to be dumped to the specified
+\fIfile_name\fR.
+This is intended for debugging only.
+.RE
+.TP
+.B \-U
+.RS
+Causes \fBpppoe\-discovery\fR to use the Host-Uniq tag in its discovery
+packets.
+This lets you run multiple instances of \fBpppoe\-discovery\fR and/or
+\fBpppoe\fR without having their discovery packets interfere with one
+another.
+You must supply this option to \fIall\fR instances that you intend to
+run simultaneously.
+.RE
+.TP
+.BI \-S " service_name"
+.RS
+Specifies the desired service name.
+\fBpppoe\-discovery\fR will only accept access concentrators which can
+provide the specified service.
+In most cases, you should \fInot\fR specify this option.
+Use it only if you know that there are multiple access concentrators
+or know that you need a specific service name.
+.RE
+.TP
+.BI \-C " ac_name"
+.RS
+Specifies the desired access concentrator name.
+\fBpppoe\-discovery\fR will only accept the specified access
+concentrator.
+In most cases, you should \fInot\fR specify this option.
+Use it only if you know that there are multiple access concentrators.
+If both the \fB\-S\fR and \fB\-C\fR options are specified, they must
+\fIboth\fR match.
+.RE
+.TP
+.B \-A
+.RS
+This option is accepted for compatibility with \fBpppoe\fR, but has no
+effect.
+.RE
+.TP
+.BR \-V " | " \-h
+.RS
+Either of these options causes \fBpppoe\-discovery\fR to print its
+version number and usage information, then exit.
+.RE
+.SH AUTHORS
+\fBpppoe\-discovery\fR was written by Marco d'Itri <md@linux.it>,
+based on \fBpppoe\fR by David F. Skoll <dfs@roaringpenguin.com>.
+.SH SEE ALSO
+pppoe(8), pppoe-sniff(8)

--- a/pppd/plugins/rp-pppoe/pppoe-discovery.c
+++ b/pppd/plugins/rp-pppoe/pppoe-discovery.c
@@ -131,7 +131,7 @@ openInterface(char const *ifname, UINT16_t type, unsigned char *hwaddr)
     stype = SOCK_PACKET;
 #endif
 
-    if ((fd = socket(domain, stype, htons(type))) < 0) {
+    if ((fd = socket(domain, stype | SOCK_CLOEXEC, htons(type))) < 0) {
 	/* Give a more helpful message for the common error case */
 	if (errno == EPERM) {
 	    rp_fatal("Cannot create raw socket -- pppoe must be run as root.");

--- a/pppd/pppd.8
+++ b/pppd/pppd.8
@@ -1178,7 +1178,7 @@ Ask the peer for up to 2 DNS server addresses.  The addresses supplied
 by the peer (if any) are passed to the /etc/ppp/ip\-up script in the
 environment variables DNS1 and DNS2, and the environment variable
 USEPEERDNS will be set to 1.  In addition, pppd will create an
-/etc/ppp/resolv.conf file containing one or two nameserver lines with
+/var/run/ppp/resolv.conf file containing one or two nameserver lines with
 the address(es) supplied by the peer.
 .TP
 .B user \fIname

--- a/pppd/pppd.h
+++ b/pppd/pppd.h
@@ -719,7 +719,7 @@ int  sipxfaddr __P((int, unsigned long, unsigned char *));
 int  cipxfaddr __P((int));
 #endif
 int  get_if_hwaddr __P((u_char *addr, char *name));
-char *get_first_ethernet __P((void));
+int get_first_ethernet __P((char **_r));
 int get_time __P((struct timeval *));
 				/* Get current time, monotonic if possible. */
 

--- a/pppd/sys-linux.c
+++ b/pppd/sys-linux.c
@@ -473,7 +473,7 @@ int generic_establish_ppp (int fd)
 	    goto err;
 	}
 	dbglog("using channel %d", chindex);
-	fd = open("/dev/ppp", O_RDWR);
+	fd = open("/dev/ppp", O_RDWR | O_CLOEXEC);
 	if (fd < 0) {
 	    error("Couldn't reopen /dev/ppp: %m");
 	    goto err;
@@ -633,7 +633,7 @@ static int make_ppp_unit()
 		dbglog("in make_ppp_unit, already had /dev/ppp open?");
 		close(ppp_dev_fd);
 	}
-	ppp_dev_fd = open("/dev/ppp", O_RDWR);
+	ppp_dev_fd = open("/dev/ppp", O_RDWR | O_CLOEXEC);
 	if (ppp_dev_fd < 0)
 		fatal("Couldn't open /dev/ppp: %m");
 	flags = fcntl(ppp_dev_fd, F_GETFL);
@@ -722,7 +722,7 @@ int bundle_attach(int ifnum)
 	if (!new_style_driver)
 		return -1;
 
-	master_fd = open("/dev/ppp", O_RDWR);
+	master_fd = open("/dev/ppp", O_RDWR | O_CLOEXEC);
 	if (master_fd < 0)
 		fatal("Couldn't open /dev/ppp: %m");
 	if (ioctl(master_fd, PPPIOCATTACH, &ifnum) < 0) {
@@ -1947,7 +1947,7 @@ int sifproxyarp (int unit, u_int32_t his_adr)
 	if (tune_kernel) {
 	    forw_path = path_to_procfs("/sys/net/ipv4/ip_forward");
 	    if (forw_path != 0) {
-		int fd = open(forw_path, O_WRONLY);
+		int fd = open(forw_path, O_WRONLY | O_CLOEXEC);
 		if (fd >= 0) {
 		    if (write(fd, "1", 1) != 1)
 			error("Couldn't enable IP forwarding: %m");
@@ -2262,7 +2262,7 @@ int ppp_available(void)
     sscanf(utsname.release, "%d.%d.%d", &osmaj, &osmin, &ospatch);
     kernel_version = KVERSION(osmaj, osmin, ospatch);
 
-    fd = open("/dev/ppp", O_RDWR);
+    fd = open("/dev/ppp", O_RDWR | O_CLOEXEC);
     if (fd >= 0) {
 	new_style_driver = 1;
 
@@ -2440,7 +2440,7 @@ void logwtmp (const char *line, const char *name, const char *host)
 #if __GLIBC__ >= 2
     updwtmp(_PATH_WTMP, &ut);
 #else
-    wtmp = open(_PATH_WTMP, O_APPEND|O_WRONLY);
+    wtmp = open(_PATH_WTMP, O_APPEND|O_WRONLY|O_CLOEXEC);
     if (wtmp >= 0) {
 	flock(wtmp, LOCK_EX);
 
@@ -2664,7 +2664,7 @@ int sifaddr (int unit, u_int32_t our_adr, u_int32_t his_adr,
 	int fd;
 
 	path = path_to_procfs("/sys/net/ipv4/ip_dynaddr");
-	if (path != 0 && (fd = open(path, O_WRONLY)) >= 0) {
+	if (path != 0 && (fd = open(path, O_WRONLY | O_CLOEXEC)) >= 0) {
 	    if (write(fd, "1", 1) != 1)
 		error("Couldn't enable dynamic IP addressing: %m");
 	    close(fd);
@@ -2840,7 +2840,7 @@ get_pty(master_fdp, slave_fdp, slave_name, uid)
     /*
      * Try the unix98 way first.
      */
-    mfd = open("/dev/ptmx", O_RDWR);
+    mfd = open("/dev/ptmx", O_RDWR | O_CLOEXEC);
     if (mfd >= 0) {
 	int ptn;
 	if (ioctl(mfd, TIOCGPTN, &ptn) >= 0) {
@@ -2851,7 +2851,7 @@ get_pty(master_fdp, slave_fdp, slave_name, uid)
 	    if (ioctl(mfd, TIOCSPTLCK, &ptn) < 0)
 		warn("Couldn't unlock pty slave %s: %m", pty_name);
 #endif
-	    if ((sfd = open(pty_name, O_RDWR | O_NOCTTY)) < 0)
+	    if ((sfd = open(pty_name, O_RDWR | O_NOCTTY | O_CLOEXEC)) < 0)
 	    {
 		warn("Couldn't open pty slave %s: %m", pty_name);
 		close(mfd);
@@ -2865,10 +2865,10 @@ get_pty(master_fdp, slave_fdp, slave_name, uid)
 	for (i = 0; i < 64; ++i) {
 	    slprintf(pty_name, sizeof(pty_name), "/dev/pty%c%x",
 		     'p' + i / 16, i % 16);
-	    mfd = open(pty_name, O_RDWR, 0);
+	    mfd = open(pty_name, O_RDWR | O_CLOEXEC, 0);
 	    if (mfd >= 0) {
 		pty_name[5] = 't';
-		sfd = open(pty_name, O_RDWR | O_NOCTTY, 0);
+		sfd = open(pty_name, O_RDWR | O_NOCTTY | O_CLOEXEC, 0);
 		if (sfd >= 0) {
 		    fchown(sfd, uid, -1);
 		    fchmod(sfd, S_IRUSR | S_IWUSR);

--- a/pppd/sys-linux.c
+++ b/pppd/sys-linux.c
@@ -1444,7 +1444,7 @@ static char *path_to_procfs(const char *tail)
 	/* Default the mount location of /proc */
 	strlcpy (proc_path, "/proc", sizeof(proc_path));
 	proc_path_len = 5;
-	fp = fopen(MOUNTED, "r");
+	fp = fopen(MOUNTED, "re");
 	if (fp != NULL) {
 	    while ((mntent = getmntent(fp)) != NULL) {
 		if (strcmp(mntent->mnt_type, MNTTYPE_IGNORE) == 0)
@@ -1504,7 +1504,7 @@ static int open_route_table (void)
     close_route_table();
 
     path = path_to_procfs("/net/route");
-    route_fd = fopen (path, "r");
+    route_fd = fopen (path, "re");
     if (route_fd == NULL) {
 	error("can't open routing table %s: %m", path);
 	return 0;

--- a/pppd/sys-linux.c
+++ b/pppd/sys-linux.c
@@ -315,12 +315,12 @@ static int modify_flags(int fd, int clear_bits, int set_bits)
 void sys_init(void)
 {
     /* Get an internet socket for doing socket ioctls. */
-    sock_fd = socket(AF_INET, SOCK_DGRAM, 0);
+    sock_fd = socket(AF_INET, SOCK_DGRAM | SOCK_CLOEXEC, 0);
     if (sock_fd < 0)
 	fatal("Couldn't create IP socket: %m(%d)", errno);
 
 #ifdef INET6
-    sock6_fd = socket(AF_INET6, SOCK_DGRAM, 0);
+    sock6_fd = socket(AF_INET6, SOCK_DGRAM | SOCK_CLOEXEC, 0);
     if (sock6_fd < 0)
 	sock6_fd = -errno;	/* save errno for later */
 #endif
@@ -2089,7 +2089,7 @@ get_if_hwaddr(u_char *addr, char *name)
 	struct ifreq ifreq;
 	int ret, sock_fd;
 
-	sock_fd = socket(AF_INET, SOCK_DGRAM, 0);
+	sock_fd = socket(AF_INET, SOCK_DGRAM | SOCK_CLOEXEC, 0);
 	if (sock_fd < 0)
 		return 0;
 	memset(&ifreq.ifr_hwaddr, 0, sizeof(struct sockaddr));
@@ -2299,7 +2299,7 @@ int ppp_available(void)
 /*
  * Open a socket for doing the ioctl operations.
  */
-    s = socket(AF_INET, SOCK_DGRAM, 0);
+    s = socket(AF_INET, SOCK_DGRAM | SOCK_CLOEXEC, 0);
     if (s < 0)
 	return 0;
 
@@ -3133,7 +3133,7 @@ ether_to_eui64(eui64_t *p_eui64)
     int skfd;
     const unsigned char *ptr;
 
-    skfd = socket(PF_INET6, SOCK_DGRAM, 0);
+    skfd = socket(PF_INET6, SOCK_DGRAM | SOCK_CLOEXEC, 0);
     if(skfd == -1)
     {
         warn("could not open IPv6 socket");

--- a/pppd/tdb.c
+++ b/pppd/tdb.c
@@ -1724,7 +1724,7 @@ TDB_CONTEXT *tdb_open_ex(const char *name, int hash_size, int tdb_flags,
 		goto internal;
 	}
 
-	if ((tdb->fd = open(name, open_flags, mode)) == -1) {
+	if ((tdb->fd = open(name, open_flags | O_CLOEXEC, mode)) == -1) {
 		TDB_LOG((tdb, 5, "tdb_open_ex: could not open file %s: %s\n",
 			 name, strerror(errno)));
 		goto fail;	/* errno set by open(2) */
@@ -1967,7 +1967,7 @@ int tdb_reopen(TDB_CONTEXT *tdb)
 	}
 	if (close(tdb->fd) != 0)
 		TDB_LOG((tdb, 0, "tdb_reopen: WARNING closing tdb->fd failed!\n"));
-	tdb->fd = open(tdb->name, tdb->open_flags & ~(O_CREAT|O_TRUNC), 0);
+	tdb->fd = open(tdb->name, (tdb->open_flags & ~(O_CREAT|O_TRUNC)) | O_CLOEXEC, 0);
 	if (tdb->fd == -1) {
 		TDB_LOG((tdb, 0, "tdb_reopen: open failed (%s)\n", strerror(errno)));
 		goto fail;

--- a/pppd/tty.c
+++ b/pppd/tty.c
@@ -572,7 +572,7 @@ int connect_tty()
 				status = EXIT_OPEN_FAILED;
 				goto errret;
 			}
-			real_ttyfd = open(devnam, O_NONBLOCK | O_RDWR, 0);
+			real_ttyfd = open(devnam, O_NONBLOCK | O_RDWR | O_CLOEXEC, 0);
 			err = errno;
 			if (prio < OPRIO_ROOT && seteuid(0) == -1)
 				fatal("Unable to regain privileges");
@@ -726,7 +726,7 @@ int connect_tty()
 	if (connector == NULL && modem && devnam[0] != 0) {
 		int i;
 		for (;;) {
-			if ((i = open(devnam, O_RDWR)) >= 0)
+			if ((i = open(devnam, O_RDWR | O_CLOEXEC)) >= 0)
 				break;
 			if (errno != EINTR) {
 				error("Failed to reopen %s: %m", devnam);

--- a/pppd/tty.c
+++ b/pppd/tty.c
@@ -899,7 +899,7 @@ open_socket(dest)
     *sep = ':';
 
     /* get a socket and connect it to the other end */
-    sock = socket(PF_INET, SOCK_STREAM, 0);
+    sock = socket(PF_INET, SOCK_STREAM | SOCK_CLOEXEC, 0);
     if (sock < 0) {
 	error("Can't create socket: %m");
 	return -1;

--- a/pppd/utils.c
+++ b/pppd/utils.c
@@ -922,14 +922,14 @@ lock(dev)
     slprintf(lock_file, sizeof(lock_file), "%s/LCK..%s", LOCK_DIR, dev);
 #endif
 
-    while ((fd = open(lock_file, O_EXCL | O_CREAT | O_RDWR, 0644)) < 0) {
+    while ((fd = open(lock_file, O_EXCL | O_CREAT | O_RDWR | O_CLOEXEC, 0644)) < 0) {
 	if (errno != EEXIST) {
 	    error("Can't create lock file %s: %m", lock_file);
 	    break;
 	}
 
 	/* Read the lock file to find out who has the device locked. */
-	fd = open(lock_file, O_RDONLY, 0);
+	fd = open(lock_file, O_RDONLY | O_CLOEXEC, 0);
 	if (fd < 0) {
 	    if (errno == ENOENT) /* This is just a timing problem. */
 		continue;
@@ -1008,7 +1008,7 @@ relock(pid)
 
     if (lock_file[0] == 0)
 	return -1;
-    fd = open(lock_file, O_WRONLY, 0);
+    fd = open(lock_file, O_WRONLY | O_CLOEXEC, 0);
     if (fd < 0) {
 	error("Couldn't reopen lock file %s: %m", lock_file);
 	lock_file[0] = 0;

--- a/pppd/utils.c
+++ b/pppd/utils.c
@@ -850,7 +850,7 @@ complete_read(int fd, void *buf, size_t count)
 /* Procedures for locking the serial device using a lock file. */
 #ifndef LOCK_DIR
 #ifdef __linux__
-#define LOCK_DIR	"/var/lock"
+#define LOCK_DIR	"/var/lock/ppp"
 #else
 #ifdef SVR4
 #define LOCK_DIR	"/var/spool/locks"

--- a/pppdump/Makefile.linux
+++ b/pppdump/Makefile.linux
@@ -5,6 +5,7 @@ MANDIR = $(DESTDIR)/share/man/man8
 CFLAGS= -O -I../include/net
 OBJS = pppdump.o bsd-comp.o deflate.o zlib.o
 
+STRIP_FLAG=-s
 INSTALL= install -p
 
 all:	pppdump
@@ -17,5 +18,5 @@ clean:
 
 install:
 	mkdir -p $(BINDIR) $(MANDIR)
-	$(INSTALL) -s -c pppdump $(BINDIR)
+	$(INSTALL) $(STRIP_FLAG) -c pppdump $(BINDIR)
 	$(INSTALL) -c -m 444 pppdump.8 $(MANDIR)

--- a/pppdump/Makefile.linux
+++ b/pppdump/Makefile.linux
@@ -5,7 +5,7 @@ MANDIR = $(DESTDIR)/share/man/man8
 CFLAGS= -O -I../include/net
 OBJS = pppdump.o bsd-comp.o deflate.o zlib.o
 
-INSTALL= install
+INSTALL= install -p
 
 all:	pppdump
 

--- a/pppdump/Makefile.linux
+++ b/pppdump/Makefile.linux
@@ -2,7 +2,8 @@ DESTDIR = $(INSTROOT)@DESTDIR@
 BINDIR = $(DESTDIR)/sbin
 MANDIR = $(DESTDIR)/share/man/man8
 
-CFLAGS= -O -I../include/net
+COPTS= -O
+CFLAGS= $(COPTS) -I../include/net
 OBJS = pppdump.o bsd-comp.o deflate.o zlib.o
 
 STRIP_FLAG=-s

--- a/pppstats/Makefile.linux
+++ b/pppstats/Makefile.linux
@@ -14,6 +14,7 @@ COPTS = -O
 COMPILE_FLAGS = -I../include
 LIBS =
 
+STRIP_FLAG=-s
 INSTALL= install -p
 
 CFLAGS = $(COPTS) $(COMPILE_FLAGS)
@@ -22,7 +23,7 @@ all: pppstats
 
 install: pppstats
 	-mkdir -p $(MANDIR)
-	$(INSTALL) -s -c pppstats $(BINDIR)
+	$(INSTALL) $(STRIP_FLAG) -c pppstats $(BINDIR)
 	$(INSTALL) -c -m 444 pppstats.8 $(MANDIR)
 
 pppstats: $(PPPSTATSRCS)

--- a/pppstats/Makefile.linux
+++ b/pppstats/Makefile.linux
@@ -14,7 +14,7 @@ COPTS = -O
 COMPILE_FLAGS = -I../include
 LIBS =
 
-INSTALL= install
+INSTALL= install -p
 
 CFLAGS = $(COPTS) $(COMPILE_FLAGS)
 

--- a/sample/auth-down
+++ b/sample/auth-down
@@ -1,0 +1,17 @@
+#!/bin/sh
+#
+# A program or script which is executed after the remote system
+# successfully authenticates itself. It is executed with the parameters
+# <interface-name> <peer-name> <user-name> <tty-device> <speed>
+#
+
+#
+# The environment is cleared before executing this script
+# so the path must be reset
+#
+PATH=/usr/sbin:/sbin:/usr/bin:/bin
+export PATH
+
+echo auth-down `date +'%y/%m/%d %T'` $* >> /var/log/pppstats
+
+# last line

--- a/sample/auth-up
+++ b/sample/auth-up
@@ -1,0 +1,17 @@
+#!/bin/sh
+#
+# A program or script which is executed after the remote system
+# successfully authenticates itself. It is executed with the parameters
+# <interface-name> <peer-name> <user-name> <tty-device> <speed>
+#
+
+#
+# The environment is cleared before executing this script
+# so the path must be reset
+#
+PATH=/usr/sbin:/sbin:/usr/bin:/bin
+export PATH
+
+echo auth-up `date +'%y/%m/%d %T'` $* >> /var/log/pppstats
+
+# last line

--- a/sample/ip-down
+++ b/sample/ip-down
@@ -1,0 +1,22 @@
+#!/bin/sh
+#
+# This script is run by the pppd _after_ the link is brought down.
+# It should be used to delete routes, unset IP addresses etc.
+#
+# This script is called with the following arguments:
+#    Arg  Name               Example
+#    $1   Interface name     ppp0
+#    $2   The tty            ttyS1
+#    $3   The link speed     38400
+#    $4   Local IP number    12.34.56.78
+#    $5   Peer  IP number    12.34.56.99
+#
+
+#
+# The  environment is cleared before executing this script
+# so the path must be reset
+#
+PATH=/usr/sbin:/sbin:/usr/bin:/bin
+export PATH
+
+# last line

--- a/sample/ip-up
+++ b/sample/ip-up
@@ -1,0 +1,23 @@
+#!/bin/sh
+#
+# This script is run by the pppd after the link is established.
+# It should be used to add routes, set IP address, run the mailq
+# etc.
+#
+# This script is called with the following arguments:
+#    Arg  Name               Example
+#    $1   Interface name     ppp0
+#    $2   The tty            ttyS1
+#    $3   The link speed     38400
+#    $4   Local IP number    12.34.56.78
+#    $5   Peer  IP number    12.34.56.99
+#
+
+#
+# The  environment is cleared before executing this script
+# so the path must be reset
+#
+PATH=/usr/sbin:/sbin:/usr/bin:/bin
+export PATH
+
+# last line

--- a/sample/options
+++ b/sample/options
@@ -1,0 +1,153 @@
+# /etc/ppp/options
+
+# The name of this server. Often, the FQDN is used here.
+#name <host>
+
+# Enforce the use of the hostname as the name of the local system for
+# authentication purposes (overrides the name option).
+usehostname
+
+# If no local IP address is given, pppd will use the first IP address
+# that belongs to the local hostname. If "noipdefault" is given, this
+# is disabled and the peer will have to supply an IP address.
+noipdefault
+
+# With this option, pppd will accept the peer's idea of our local IP
+# address, even if the local IP address was specified in an option.
+#ipcp-accept-local
+
+# With this option, pppd will accept the peer's idea of its (remote) IP
+# address, even if the remote IP address was specified in an option.
+#ipcp-accept-remote
+
+# Specify which DNS Servers the incoming Win95 or WinNT Connection should use
+# Two Servers can be remotely configured
+#ms-dns 192.168.1.1
+#ms-dns 192.168.1.2
+
+# Specify which WINS Servers the incoming connection Win95 or WinNT should use
+#wins-addr 192.168.1.50
+#wins-addr 192.168.1.51
+
+# enable this on a server that already has a permanent default route
+#nodefaultroute
+
+# Run the executable or shell command specified after pppd has terminated
+# the link.  This script could, for example, issue commands to the modem
+# to cause it to hang up if hardware modem control signals were not
+# available.
+# If mgetty is running, it will reset the modem anyway. So there is no need
+# to do it here.
+#disconnect "chat -- \d+++\d\c OK ath0 OK"
+
+# Increase debugging level (same as -d). The debug output is written
+# to syslog LOG_LOCAL2.
+debug
+
+# Enable debugging code in the kernel-level PPP driver.  The argument n
+# is a number which is the sum of the following values: 1 to enable
+# general debug messages, 2 to request that the contents of received
+# packets be printed, and 4 to request that the contents of transmitted
+# packets be printed.
+#kdebug n
+
+# Require the peer to authenticate itself before allowing network
+# packets to be sent or received.
+# Please do not disable this setting. It is expected to be standard in
+# future releases of pppd. Use the call option (see manpage) to disable
+# authentication for specific peers.
+#auth
+
+# authentication can either be pap or chap. As most people only want to
+# use pap, you can also disable chap:
+#require-pap
+#refuse-chap
+
+# Use hardware flow control (i.e. RTS/CTS) to control the flow of data
+# on the serial port.
+crtscts
+
+# Specifies that pppd should use a UUCP-style lock on the serial device
+# to ensure exclusive access to the device.
+lock
+
+# Use the modem control lines.
+modem
+
+# async character map -- 32-bit hex; each bit is a character
+# that needs to be escaped for pppd to receive it.  0x00000001
+# represents '\x01', and 0x80000000 represents '\x1f'.
+# To allow pppd to work over a rlogin/telnet connection, ou should escape
+# XON (^Q), XOFF  (^S) and ^]: (The peer should use "escape ff".)
+#asyncmap  200a0000
+asyncmap 0
+
+# Specifies that certain characters should be escaped on transmission
+# (regardless of whether the peer requests them to be escaped with its
+# async control character map).  The characters to be escaped are
+# specified as a list of hex numbers separated by commas.  Note that
+# almost any character can be specified for the escape option, unlike
+# the asyncmap option which only allows control characters to be
+# specified.  The characters which may not be escaped are those with hex
+# values 0x20 - 0x3f or 0x5e.
+#escape 11,13,ff
+
+# Set the MRU [Maximum Receive Unit] value to <n> for negotiation.  pppd
+# will ask the peer to send packets of no more than <n> bytes. The
+# minimum MRU value is 128.  The default MRU value is 1500.  A value of
+# 296 is recommended for slow links (40 bytes for TCP/IP header + 256
+# bytes of data).
+#mru 542
+
+# Set the MTU [Maximum Transmit Unit] value to <n>. Unless the peer
+# requests a smaller value via MRU negotiation, pppd will request that
+# the kernel networking code send data packets of no more than n bytes
+# through the PPP network interface.
+#mtu <n>
+
+# Set the interface netmask to <n>, a 32 bit netmask in "decimal dot"
+# notation (e.g. 255.255.255.0).
+#netmask 255.255.255.0
+
+# Don't fork to become a background process (otherwise pppd will do so
+# if a serial device is specified).
+nodetach
+
+# Set the assumed name of the remote system for authentication purposes
+# to <n>.
+#remotename <n>
+
+# Add an entry to this system's ARP [Address Resolution Protocol]
+# table with the IP address of the peer and the Ethernet address of this
+# system. {proxyarp,noproxyarp}
+proxyarp
+
+# Use the system password database for authenticating the peer using
+# PAP. Note: mgetty already provides this option. If this is specified
+# then dialin from users using a script under Linux to fire up ppp wont work.
+#login
+
+# If this option is given, pppd will send an LCP echo-request frame to
+# the peer every n seconds. Under Linux, the echo-request is sent when
+# no packets have been received from the peer for n seconds. Normally
+# the peer should respond to the echo-request by sending an echo-reply.
+# This option can be used with the lcp-echo-failure option to detect
+# that the peer is no longer connected.
+lcp-echo-interval 30
+
+# If this option is given, pppd will presume the peer to be dead if n
+# LCP echo-requests are sent without receiving a valid LCP echo-reply.
+# If this happens, pppd will terminate the connection.  Use of this
+# option requires a non-zero value for the lcp-echo-interval parameter.
+# This option can be used to enable pppd to terminate after the physical
+# connection has been broken (e.g., the modem has hung up) in
+# situations where no hardware modem control lines are available.
+lcp-echo-failure 4
+
+# Specifies that pppd should disconnect if the link is idle for n seconds.
+idle 600
+
+# Disable the IPXCP and IPX protocols.
+noipx
+
+# ---<End of File>---

--- a/sample/options.ttyXX
+++ b/sample/options.ttyXX
@@ -1,0 +1,14 @@
+# If you need to set up multiple serial lines then copy this file to
+# options.<ttyname> for each tty with a modem on it.
+#
+# The options.tty file will assign an IP address to each PPP connection
+# as it comes up. They must all be distinct!
+#
+# Example:
+# options.ttyS1		for com2 under DOS.
+#
+# Edit the following line so that the first IP address
+# mentioned is the ip address of the serial port while the second
+# is the IP address of your host
+#
+hostname-s1:hostname

--- a/sample/pap-secrets
+++ b/sample/pap-secrets
@@ -1,0 +1,28 @@
+# Secrets for authentication using PAP
+# client	server	secret			IP addresses
+
+# OUTBOUND CONNECTIONS
+# Here you should add your userid password to connect to your providers via
+# pap. The * means that the password is to be used for ANY host you connect
+# to. Thus you do not have to worry about the foreign machine name. Just
+# replace password with your password.
+# If you have different providers with different passwords then you better
+# remove the following line.
+#hostname	*	password
+
+# INBOUND CONNECTIONS
+#client		hostname	<password>	192.168.1.1
+
+# If you add "auth login -chap +pap" to /etc/mgetty+sendfax/login.config,
+# all users in /etc/passwd can use their password for pap-authentication.
+#
+# Every regular user can use PPP and has to use passwords from /etc/passwd
+#*	hostname	""
+# UserIDs that cannot use PPP at all. Check your /etc/passwd and add any
+# other accounts that should not be able to use pppd! Replace hostname
+# with your local hostname.
+#guest		hostname	"*"	-
+#master		hostname	"*"	-
+#root		hostname	"*"	-
+#support	hostname	"*"	-
+#stats		hostname	"*"	-

--- a/scripts/ip-down.local.add
+++ b/scripts/ip-down.local.add
@@ -9,12 +9,13 @@
 #
 # Nick Walker (nickwalker@email.com)
 #
+. /etc/sysconfig/network-scripts/network-functions
 
-if [ -n "$USEPEERDNS" -a -f /etc/ppp/resolv.conf ]; then
-	if [ -f /etc/ppp/resolv.prev ]; then
-		cp -f /etc/ppp/resolv.prev /etc/resolv.conf
+if [ -n "$USEPEERDNS" -a -f /var/run/ppp/resolv.conf ]; then
+	if [ -f /var/run/ppp/resolv.prev ]; then
+		change_resolv_conf /var/run/ppp/resolv.prev
 	else
-		rm -f /etc/resolv.conf
+		change_resolv_conf
 	fi
 fi
 

--- a/scripts/ip-up.local.add
+++ b/scripts/ip-up.local.add
@@ -9,16 +9,19 @@
 #
 # Nick Walker (nickwalker@email.com)
 #
+. /etc/sysconfig/network-scripts/network-functions
 
-if [ -n "$USEPEERDNS" -a -f /etc/ppp/resolv.conf ]; then
-	rm -f /etc/ppp/resolv.prev
+if [ -n "$USEPEERDNS" -a -f /var/run/ppp/resolv.conf ]; then
+	rm -f /var/run/ppp/resolv.prev
 	if [ -f /etc/resolv.conf ]; then
-		cp /etc/resolv.conf /etc/ppp/resolv.prev
-		grep domain /etc/ppp/resolv.prev > /etc/resolv.conf
-		grep search /etc/ppp/resolv.prev >> /etc/resolv.conf
-		cat /etc/ppp/resolv.conf >> /etc/resolv.conf
+		cp /etc/resolv.conf /var/run/ppp/resolv.prev
+		rscf=/var/run/ppp/resolv.new
+		grep domain /var/run/ppp/resolv.prev > $rscf
+		grep search /var/run/ppp/resolv.prev >> $rscf
+		change_resolv_conf $rscf
+		rm -f $rscf
 	else
-		cp /etc/ppp/resolv.conf /etc
+		change_resolv_conf /var/run/ppp/resolv.conf
 	fi
 fi
 

--- a/scripts/ip-up.local.add
+++ b/scripts/ip-up.local.add
@@ -18,6 +18,9 @@ if [ -n "$USEPEERDNS" -a -f /var/run/ppp/resolv.conf ]; then
 		rscf=/var/run/ppp/resolv.new
 		grep domain /var/run/ppp/resolv.prev > $rscf
 		grep search /var/run/ppp/resolv.prev >> $rscf
+		if [ -f /var/run/ppp/resolv.conf ]; then
+			cat /var/run/ppp/resolv.conf >> $rscf
+		fi
 		change_resolv_conf $rscf
 		rm -f $rscf
 	else

--- a/scripts/secure-card
+++ b/scripts/secure-card
@@ -1,4 +1,4 @@
-#!/usr/local/bin/expect -f
+#!/usr/bin/expect -f
 #
 # This  script was  written  by  Jim Isaacson  <jcisaac@crl.com>.  It is
 # designed to work  as a script to use the  SecureCARD(tm) device.  This


### PR DESCRIPTION
Downstream patches we currently use in Fedora. They are slightly reworked to apply to master. It's related to #111. 

We also apply https://www.nikhef.nl/~janjust/ppp/ppp-2.4.8-eaptls-mppe-1.300.patch. I don't know why it's not upstreamed. It works quite OK in Fedora for a while.
