### PR TITLE
Close discovery socket after session completed

### DIFF
--- a/pppd/plugins/rp-pppoe/discovery.c
+++ b/pppd/plugins/rp-pppoe/discovery.c
@@ -659,6 +659,8 @@ discovery(PPPoEConnection *conn)
     }
 
     /* We're done. */
+    close(conn->discoverySocket);
+    conn->discoverySocket = -1;
     conn->discoveryState = STATE_SESSION;
     return;
 }


### PR DESCRIPTION
After the session is complete, the socket is left unmanaged. When the
interface receives PADIs from other device, the packets are put
in the socket's Recv-Q, which eat system memory.

[root@test ~]# ss -f link
Netid  Recv-Q Send-Q    Local Address:Port    Peer Address:Port
p_raw  10269952 0          ppp_disc:eth1           *

Signed-off-by: Xing Qingjie <88930741@qq.com>