### PR TITLE
be sure to close /dev/ppp when reconnecting

### DIFF
--- a/pppd/sys-linux.c
+++ b/pppd/sys-linux.c
@@ -467,6 +467,13 @@ int generic_establish_ppp (int fd)
     if (new_style_driver) {
 	int flags;
 
+	/* If a ppp_fd is already open, close it first */
+	if (ppp_fd >= 0) {
+	    close(ppp_fd);
+	    remove_fd(ppp_fd);
+	    ppp_fd = -1;
+	}
+
 	/* Open an instance of /dev/ppp and connect the channel to it */
 	if (ioctl(fd, PPPIOCGCHAN, &chindex) == -1) {
 	    error("Couldn't get channel number: %m");


### PR DESCRIPTION
From https://bugs.debian.org/306261

When using the kernel PPPoE driver, pppd never
closes /dev/ppp when the link has come down.

It opens superfluous fds to the device each time it re-opens the
connection, with the unclosed ones falsely reported always ready for
data by select().

This makes pppd eat up 100% CPU time after the first persist because of
the always instantly returning select() on the unclosed fds.

The problem also occurs with the upstream version, but does not occur
when a pty/tty device is used for the ppp connection.

Signed-off-by: Samuel Thibault <samuel.thibault@ens-lyon.org>