### PR TITLE
make sure that the linkpidfile is always created

### DIFF
--- a/pppd/main.c
+++ b/pppd/main.c
@@ -763,8 +763,7 @@ detach(void)
 	/* update pid files if they have been written already */
 	if (pidfilename[0])
 	    create_pidfile(pid);
-	if (linkpidfile[0])
-	    create_linkpidfile(pid);
+	create_linkpidfile(pid);
 	exit(0);		/* parent dies */
     }
     setsid();


### PR DESCRIPTION
From https://bugs.debian.org/284382

When pppd detaches from the parent normally, that is, without nodetach
or updetach set, the linkpidfile is not created even when linkname is
set.

This is because the create_linkpidfile call in detach() is only made
if the linkpidfile is filled in.  However, linkpidfile is never filled
in until create_linkpidfile has been called.

IMHO the call should be made uncondtionally in detach() since
create_linkpidfile does its own check on linkname anyway.

Please note that the version of pppd in woody always wrote the
linkpidfile after detaching.  It did so in main() however.  That
call has now been removed which is why I'm seeing this problem.

Signed-off-by: Samuel Thibault <samuel.thibault@ens-lyon.org>