### PR TITLE
Do not strip installed binaries

### DIFF
--- a/chat/Makefile.linux
+++ b/chat/Makefile.linux
@@ -25,7 +25,7 @@ chat.o:	chat.c
 
 install: chat
 	mkdir -p $(BINDIR) $(MANDIR)
-	$(INSTALL) -s -c chat $(BINDIR)
+	$(INSTALL) -c chat $(BINDIR)
 	$(INSTALL) -c -m 644 chat.8 $(MANDIR)
 
 clean:

--- a/pppd/Makefile.linux
+++ b/pppd/Makefile.linux
@@ -112,7 +112,7 @@ CFLAGS	+= -DUSE_SRP -DOPENSSL -I/usr/local/ssl/include
 LIBS	+= -lsrp -L/usr/local/ssl/lib
 NEEDCRYPTOLIB = y
 TARGETS	+= srp-entry
-EXTRAINSTALL = $(INSTALL) -s -c -m 555 srp-entry $(BINDIR)/srp-entry
+EXTRAINSTALL = $(INSTALL) -c -m 555 srp-entry $(BINDIR)/srp-entry
 MANPAGES += srp-entry.8
 EXTRACLEAN += srp-entry.o
 NEEDDES=y
@@ -238,7 +238,7 @@ all: $(TARGETS)
 install: pppd
 	mkdir -p $(BINDIR) $(MANDIR)
 	$(EXTRAINSTALL)
-	$(INSTALL) -s -c -m 555 pppd $(BINDIR)/pppd
+	$(INSTALL) -c -m 555 pppd $(BINDIR)/pppd
 	if chgrp pppusers $(BINDIR)/pppd 2>/dev/null; then \
 	  chmod o-rx,u+s $(BINDIR)/pppd; fi
 	$(INSTALL) -c -m 444 pppd.8 $(MANDIR)

--- a/pppd/plugins/radius/Makefile.linux
+++ b/pppd/plugins/radius/Makefile.linux
@@ -36,9 +36,9 @@ all: $(PLUGIN)
 
 install: all
 	$(INSTALL) -d -m 755 $(LIBDIR)
-	$(INSTALL) -s -c -m 755 radius.so $(LIBDIR)
-	$(INSTALL) -s -c -m 755 radattr.so $(LIBDIR)
-	$(INSTALL) -s -c -m 755 radrealms.so $(LIBDIR)
+	$(INSTALL) -c -m 755 radius.so $(LIBDIR)
+	$(INSTALL) -c -m 755 radattr.so $(LIBDIR)
+	$(INSTALL) -c -m 755 radrealms.so $(LIBDIR)
 	$(INSTALL) -c -m 444 pppd-radius.8 $(MANDIR)
 	$(INSTALL) -c -m 444 pppd-radattr.8 $(MANDIR)
 

--- a/pppd/plugins/rp-pppoe/Makefile.linux
+++ b/pppd/plugins/rp-pppoe/Makefile.linux
@@ -43,9 +43,9 @@ rp-pppoe.so: plugin.o discovery.o if.o common.o
 
 install: all
 	$(INSTALL) -d -m 755 $(LIBDIR)
-	$(INSTALL) -s -c -m 4550 rp-pppoe.so $(LIBDIR)
+	$(INSTALL) -c -m 4550 rp-pppoe.so $(LIBDIR)
 	$(INSTALL) -d -m 755 $(BINDIR)
-	$(INSTALL) -s -c -m 555 pppoe-discovery $(BINDIR)
+	$(INSTALL) -c -m 555 pppoe-discovery $(BINDIR)
 
 clean:
 	rm -f *.o *.so pppoe-discovery

--- a/pppdump/Makefile.linux
+++ b/pppdump/Makefile.linux
@@ -17,5 +17,5 @@ clean:
 
 install:
 	mkdir -p $(BINDIR) $(MANDIR)
-	$(INSTALL) -s -c pppdump $(BINDIR)
+	$(INSTALL) -c pppdump $(BINDIR)
 	$(INSTALL) -c -m 444 pppdump.8 $(MANDIR)

--- a/pppstats/Makefile.linux
+++ b/pppstats/Makefile.linux
@@ -22,7 +22,7 @@ all: pppstats
 
 install: pppstats
 	-mkdir -p $(MANDIR)
-	$(INSTALL) -s -c pppstats $(BINDIR)
+	$(INSTALL) -c pppstats $(BINDIR)
 	$(INSTALL) -c -m 444 pppstats.8 $(MANDIR)
 
 pppstats: $(PPPSTATSRCS)


### PR DESCRIPTION
This should be done by the packaging system, to be able to separate out
debugging symbols into separate packages.

Signed-off-by: Samuel Thibault <samuel.thibault@ens-lyon.org>