### PR TITLE
Fix pppoatm plugin for pppd to accept a wildcard argument for an ATM …

### DIFF
--- a/pppd/plugins/pppoatm/pppoatm.c
+++ b/pppd/plugins/pppoatm/pppoatm.c
@@ -75,7 +75,7 @@ static int setdevname_pppoatm(const char *cp, const char **argv, int doit)
 	//info("PPPoATM setdevname_pppoatm: '%s'", cp);
 	memset(&addr, 0, sizeof addr);
 	if (text2atm(cp, (struct sockaddr *) &addr, sizeof(addr),
-	    T2A_PVC | T2A_NAME) < 0) {
+	    T2A_PVC | T2A_NAME | T2A_WILDCARD) < 0) {
                if(doit)
                    info("atm does not recognize: %s", cp);
 		return 0;


### PR DESCRIPTION
…device

From https://bugs.debian.org/376990

This becomes an issue when using a USB ADSL modem (e.g. Alcatel Speedtouch)
and the USB host controller disconnects the modem, then later re-connects it
with a new USB address and consequently a new ATM device number.

Signed-off-by: Samuel Thibault <samuel.thibault@ens-lyon.org>