### PR TITLE
add support for the Framed-MTU Radius attribute

### DIFF
--- a/pppd/plugins/radius/radius.c
+++ b/pppd/plugins/radius/radius.c
@@ -651,6 +651,9 @@ radius_setparams(VALUE_PAIR *vp, char *msg, REQUEST_INFO *req_info,
 		    memcpy(rstate.class, vp->strvalue, rstate.class_len);
 		} /* else too big for our buffer - ignore it */
 		break;
+	    case PW_FRAMED_MTU:
+		netif_set_mtu(rstate.client_port,MIN(netif_get_mtu(rstate.client_port),vp->lvalue));
+		break;
 	    }
 
 


### PR DESCRIPTION
This allows radius plugin to deal with Framed-MTU Radius attribute and to
set MTU on interface.

Signed-off-by: Samuel Thibault <samuel.thibault@ens-lyon.org>