### PR TITLE
Fix buffer overflow in rc_mksid()

### DIFF
--- a/pppd/plugins/radius/util.c
+++ b/pppd/plugins/radius/util.c
@@ -77,7 +77,7 @@ rc_mksid (void)
   static unsigned short int cnt = 0;
   slprintf(buf, sizeof(buf), "%08lX%04X%02hX",
 	   (unsigned long int) time (NULL),
-	   (unsigned int) getpid (),
+	   (unsigned int) getpid () & 0xFFFF,
 	   cnt & 0xFF);
   cnt++;
   return buf;


### PR DESCRIPTION
rc_mksid converts the PID of pppd to hex to generate a pseudo-unique string.

If the process id is bigger than 65535 (FFFF), its hex representation will be
longer than 4 characters, resulting in a buffer overflow.

The bug can be exploited to cause a remote DoS.

Signed-off-by: Samuel Thibault <samuel.thibault@ens-lyon.org>