### PR TITLE
make _PATH_CONNERRS world readable

### DIFF
--- a/pppd/main.c
+++ b/pppd/main.c
@@ -1640,7 +1640,7 @@ device_script(char *program, int in, int out, int dont_wait)
     if (log_to_fd >= 0)
 	errfd = log_to_fd;
     else
-	errfd = open(_PATH_CONNERRS, O_WRONLY | O_APPEND | O_CREAT, 0600);
+	errfd = open(_PATH_CONNERRS, O_WRONLY | O_APPEND | O_CREAT, 0644);
 
     ++conn_running;
     pid = safe_fork(in, out, errfd);


### PR DESCRIPTION
From https://bugs.debian.org/341853

There is nothing security-sensitive there.

Signed-off-by: Samuel Thibault <samuel.thibault@ens-lyon.org>