### PR TITLE
Change path to expect in secure-card example script

### DIFF
--- a/scripts/secure-card
+++ b/scripts/secure-card
@@ -1,4 +1,4 @@
-#!/usr/local/bin/expect -f
+#!/usr/bin/expect -f
 #
 # This  script was  written  by  Jim Isaacson  <jcisaac@crl.com>.  It is
 # designed to work  as a script to use the  SecureCARD(tm) device.  This


### PR DESCRIPTION
People would usually just install expect from their distribution

Signed-off-by: Samuel Thibault <samuel.thibault@ens-lyon.org>