### PR TITLE
export $CALL_FILE to the link scripts

### DIFF
--- a/pppd/options.c
+++ b/pppd/options.c
@@ -1442,6 +1442,7 @@ callfile(char **argv)
     if ((fname = (char *) malloc(l)) == NULL)
 	novm("call file name");
     slprintf(fname, l, "%s%s", _PATH_PEERFILES, arg);
+    script_setenv("CALL_FILE", arg, 0);
 
     ok = options_from_file(fname, 1, 1, 1);
 

--- a/pppd/pppd.8
+++ b/pppd/pppd.8
@@ -1760,6 +1760,9 @@ the connection.
 .B LINKNAME
 The logical name of the link, set with the \fIlinkname\fR option.
 .TP
+.B CALL_FILE
+The value of the \fIcall\fR option.
+.TP
 .B DNS1
 If the peer supplies DNS server addresses, this variable is set to the
 first DNS server address supplied (whether or not the usepeerdns


### PR DESCRIPTION
From https://bugs.debian.org/51880

“
This would make it much easier for me, and cleaner too, to handle
multiple, mutually exclusive, dialout internet service providers.
”

Signed-off-by: Samuel Thibault <samuel.thibault@ens-lyon.org>