### PR TITLE
Use a compile test to detect crypt.h

### DIFF
--- a/pppd/Makefile.linux
+++ b/pppd/Makefile.linux
@@ -140,7 +140,7 @@ CFLAGS   += -DHAS_SHADOW
 #LIBS     += -lshadow $(LIBS)
 endif
 
-ifneq ($(wildcard $(shell $(CC) --print-sysroot)/usr/include/crypt.h),)
+ifeq ($(shell echo '\#include <crypt.h>' | $(CC) -E - >/dev/null 2>&1 && echo yes),yes)
 CFLAGS  += -DHAVE_CRYPT_H=1
 LIBS	+= -lcrypt
 endif


### PR DESCRIPTION
ppp checks header for existence of crypt.h looking it up in /usr/include.
That's incompatible with non-glibcs or a glibc with multiarch headers
(https://bugs.debian.org/798955). This patch replaces the file existence
test with a compile test.

Reviewed-by: Chris Boot <bootc@debian.org>
Signed-off-by: Samuel Thibault <samuel.thibault@ens-lyon.org>