### PR TITLE
Add replacedefaultroute option

### DIFF
--- a/pppd/ipcp.h
+++ b/pppd/ipcp.h
@@ -68,6 +68,7 @@ typedef struct ipcp_options {
     bool old_addrs;		/* Use old (IP-Addresses) option? */
     bool req_addr;		/* Ask peer to send IP address? */
     bool default_route;		/* Assign default route through interface? */
+    bool replace_default_route;	/* Replace default route through interface? */
     bool proxy_arp;		/* Make proxy ARP entry for peer? */
     bool neg_vj;		/* Van Jacobson Compression? */
     bool old_vj;		/* use old (short) form of VJ option? */

--- a/pppd/pppd.8
+++ b/pppd/pppd.8
@@ -133,6 +133,11 @@ the gateway, when IPv6CP negotiation is successfully completed.
 This entry is removed when the PPP connection is broken.  This option
 is privileged if the \fInodefaultroute6\fR option has been specified.
 .TP
+.B replacedefaultroute
+This option is a flag to the defaultroute option. If defaultroute is
+set and this flag is also set, pppd replaces an existing default route
+with the new default route.  This option is privileged.
+.TP
 .B disconnect \fIscript
 Execute the command specified by \fIscript\fR, by passing it to a
 shell, after
@@ -792,8 +797,12 @@ disable both forms of hardware flow control.
 .TP
 .B nodefaultroute
 Disable the \fIdefaultroute\fR option.  The system administrator who
-wishes to prevent users from creating default routes with pppd
+wishes to prevent users from adding a default route with pppd
 can do so by placing this option in the /etc/ppp/options file.
+.TP
+.B noreplacedefaultroute
+Disable the \fIreplacedefaultroute\fR option. This allows to disable a
+\fIreplacedefaultroute\fR option set previously in the configuration.
 .TP
 .B nodefaultroute6
 Disable the \fIdefaultroute6\fR option.  The system administrator who

--- a/pppd/pppd.h
+++ b/pppd/pppd.h
@@ -678,7 +678,7 @@ int  sif6addr(int, eui64_t, eui64_t);
 int  cif6addr(int, eui64_t, eui64_t);
 				/* Remove an IPv6 address from i/f */
 #endif
-int  sifdefaultroute(int, u_int32_t, u_int32_t);
+int  sifdefaultroute(int, u_int32_t, u_int32_t, bool replace_default_rt);
 				/* Create default route through i/f */
 int  cifdefaultroute(int, u_int32_t, u_int32_t);
 				/* Delete default route through i/f */

--- a/pppd/sys-linux.c
+++ b/pppd/sys-linux.c
@@ -209,6 +209,8 @@ static int	if_is_up;	/* Interface has been marked up */
 static int	if6_is_up;	/* Interface has been marked up for IPv6, to help differentiate */
 static int	have_default_route;	/* Gateway for default route added */
 static int	have_default_route6;	/* Gateway for default IPv6 route added */
+static struct	rtentry old_def_rt;	/* Old default route */
+static int	default_rt_repl_rest;	/* replace and restore old default rt */
 static u_int32_t proxy_arp_addr;	/* Addr for proxy arp entry added */
 static char proxy_arp_dev[16];		/* Device for proxy arp entry */
 static u_int32_t our_old_addr;		/* for detecting address changes */
@@ -1566,6 +1568,9 @@ static int read_route_table(struct rtentry *rt)
 	p = NULL;
     }
 
+    SET_SA_FAMILY (rt->rt_dst,     AF_INET);
+    SET_SA_FAMILY (rt->rt_gateway, AF_INET);
+
     SIN_ADDR(rt->rt_dst) = strtoul(cols[route_dest_col], NULL, 16);
     SIN_ADDR(rt->rt_gateway) = strtoul(cols[route_gw_col], NULL, 16);
     SIN_ADDR(rt->rt_genmask) = strtoul(cols[route_mask_col], NULL, 16);
@@ -1638,20 +1643,53 @@ int have_route_to(u_int32_t addr)
 /********************************************************************
  *
  * sifdefaultroute - assign a default route through the address given.
+ *
+ * If the global default_rt_repl_rest flag is set, then this function
+ * already replaced the original system defaultroute with some other
+ * route and it should just replace the current defaultroute with
+ * another one, without saving the current route. Use: demand mode,
+ * when pppd sets first a defaultroute it it's temporary ppp0 addresses
+ * and then changes the temporary addresses to the addresses for the real
+ * ppp connection when it has come up.
  */
 
-int sifdefaultroute (int unit, u_int32_t ouraddr, u_int32_t gateway)
+int sifdefaultroute (int unit, u_int32_t ouraddr, u_int32_t gateway, bool replace)
 {
-    struct rtentry rt;
+    struct rtentry rt, tmp_rt;
+    struct rtentry *del_rt = NULL;
 
-    if (defaultroute_exists(&rt, dfl_route_metric) && strcmp(rt.rt_dev, ifname) != 0) {
-	if (rt.rt_flags & RTF_GATEWAY)
-	    error("not replacing existing default route via %I with metric %d",
-		  SIN_ADDR(rt.rt_gateway), dfl_route_metric);
-	else
-	    error("not replacing existing default route through %s with metric %d",
-		  rt.rt_dev, dfl_route_metric);
-	return 0;
+    if (default_rt_repl_rest) {
+	/* We have already replaced the original defaultroute, if we
+	 * are called again, we will delete the current default route
+	 * and set the new default route in this function.
+	 * - this is normally only the case the doing demand: */
+	if (defaultroute_exists(&tmp_rt, -1))
+	    del_rt = &tmp_rt;
+    } else if (defaultroute_exists(&old_def_rt, -1           ) &&
+			    strcmp( old_def_rt.rt_dev, ifname) != 0) {
+	/*
+	 * We did not yet replace an existing default route, let's
+	 * check if we should save and replace a default route:
+	 */
+	u_int32_t old_gateway = SIN_ADDR(old_def_rt.rt_gateway);
+
+	if (old_gateway != gateway) {
+	    if (!replace) {
+		error("not replacing default route to %s [%I]",
+			old_def_rt.rt_dev, old_gateway);
+		return 0;
+	    } else {
+		/* we need to copy rt_dev because we need it permanent too: */
+		char * tmp_dev = malloc(strlen(old_def_rt.rt_dev)+1);
+		strcpy(tmp_dev, old_def_rt.rt_dev);
+		old_def_rt.rt_dev = tmp_dev;
+
+		notice("replacing old default route to %s [%I]",
+			old_def_rt.rt_dev, old_gateway);
+		default_rt_repl_rest = 1;
+		del_rt = &old_def_rt;
+	    }
+	}
     }
 
     memset (&rt, 0, sizeof (rt));
@@ -1671,6 +1709,12 @@ int sifdefaultroute (int unit, u_int32_t ouraddr, u_int32_t gateway)
 	    error("default route ioctl(SIOCADDRT): %m");
 	return 0;
     }
+    if (default_rt_repl_rest && del_rt)
+	if (ioctl(sock_fd, SIOCDELRT, del_rt) < 0) {
+	    if ( ! ok_error ( errno ))
+		error("del old default route ioctl(SIOCDELRT): %m(%d)", errno);
+	    return 0;
+	}
 
     have_default_route = 1;
     return 1;
@@ -1708,6 +1752,16 @@ int cifdefaultroute (int unit, u_int32_t ouraddr, u_int32_t gateway)
 		error("default route ioctl(SIOCDELRT): %m");
 	    return 0;
 	}
+    }
+    if (default_rt_repl_rest) {
+	notice("restoring old default route to %s [%I]",
+			old_def_rt.rt_dev, SIN_ADDR(old_def_rt.rt_gateway));
+	if (ioctl(sock_fd, SIOCADDRT, &old_def_rt) < 0) {
+	    if ( ! ok_error ( errno ))
+		error("restore default route ioctl(SIOCADDRT): %m(%d)", errno);
+	    return 0;
+	}
+	default_rt_repl_rest = 0;
     }
 
     return 1;

--- a/pppd/sys-solaris.c
+++ b/pppd/sys-solaris.c
@@ -2082,9 +2082,14 @@ cifaddr(int u, u_int32_t o, u_int32_t h)
  * sifdefaultroute - assign a default route through the address given.
  */
 int
-sifdefaultroute(int u, u_int32_t l, u_int32_t g)
+sifdefaultroute(int u, u_int32_t l, u_int32_t g, bool replace)
 {
     struct rtentry rt;
+
+    if (replace) {
+	error("Replacing the default route is not implemented on Solaris yet");
+	return 0;
+    }
 
 #if defined(__USLC__)
     g = l;			/* use the local address as gateway */


### PR DESCRIPTION
Adds an option to pppd to control whether to replace existing default routes
when using the 'defaultroute' option.

If defaultroute and replacedefaultroute are both set, pppd replaces an existing
default route with the new default route. The old default route is restored when
the connection is taken down.

Signed-off-by: Samuel Thibault <samuel.thibault@ens-lyon.org>