### PR TITLE
pppd/Makefile.linux: do not check for bpf header presence on the host

### DIFF
--- a/pppd/Makefile.linux
+++ b/pppd/Makefile.linux
@@ -207,10 +207,8 @@ LIBS	+= -ldl
 endif
 
 ifdef FILTER
-ifneq ($(wildcard /usr/include/pcap-bpf.h),)
 LIBS    += -lpcap
 CFLAGS  += -DPPP_FILTER
-endif
 endif
 
 ifdef HAVE_INET6


### PR DESCRIPTION
This makes builds non-deterministic, and doesn't work
when building in sysroot environments (such as yocto).

Signed-off-by: Alexander Kanavin <alex.kanavin@gmail.com>