### PR TITLE
pppd/Makefile.linux: guard libutil usage with musl non-define

### DIFF
--- a/pppd/Makefile.linux
+++ b/pppd/Makefile.linux
@@ -79,7 +79,9 @@ PLUGIN=y
 #USE_SRP=y
 
 # Use libutil
+ifndef USE_MUSL
 USE_LIBUTIL=y
+endif
 
 # Enable EAP-TLS authentication (requires MPPE support, libssl and libcrypto)
 USE_EAPTLS=y


### PR DESCRIPTION
libutil is only available in glibc, and otherwise needs to be
disabled.

Signed-off-by: Alexander Kanavin <alex.kanavin@gmail.com>