### PR TITLE
Deduplicate ether_to_eui64() implementation

### DIFF
--- a/pppd/ipv6cp.c
+++ b/pppd/ipv6cp.c
@@ -1056,6 +1056,46 @@ endswitch:
 
 
 /*
+ * ether_to_eui64 - Convert 48-bit Ethernet address into 64-bit EUI
+ *
+ * walks the list of valid ethernet interfaces, and convert the first
+ * found 48-bit MAC address into EUI 64. caller also assumes that
+ * the system has a properly configured Ethernet interface for this
+ * function to return non-zero.
+ */
+static int
+ether_to_eui64(eui64_t *p_eui64)
+{
+    u_char addr[6];
+    char *if_name;
+
+    if ((if_name = get_first_ethernet()) == NULL) {
+        error("no persistent id can be found");
+        return 0;
+    }
+
+    if (get_if_hwaddr(addr, if_name) < 0) {
+        error("could not obtain hardware address for %s", if_name);
+        return 0;
+    }
+
+    /*
+     * And convert the EUI-48 into EUI-64, per RFC 2472 [sec 4.1]
+     */
+    p_eui64->e8[0] = addr[0] | 0x02;
+    p_eui64->e8[1] = addr[1];
+    p_eui64->e8[2] = addr[2];
+    p_eui64->e8[3] = 0xFF;
+    p_eui64->e8[4] = 0xFE;
+    p_eui64->e8[5] = addr[3];
+    p_eui64->e8[6] = addr[4];
+    p_eui64->e8[7] = addr[5];
+
+    return 1;
+}
+
+
+/*
  * ipv6_check_options - check that any IP-related options are OK,
  * and assign appropriate defaults.
  */

--- a/pppd/pppd.h
+++ b/pppd/pppd.h
@@ -672,7 +672,6 @@ int  sifaddr(int, u_int32_t, u_int32_t, u_int32_t);
 int  cifaddr(int, u_int32_t, u_int32_t);
 				/* Reset i/f IP addresses */
 #ifdef INET6
-int  ether_to_eui64(eui64_t *p_eui64);	/* convert eth0 hw address to EUI64 */
 int  sif6up(int);		/* Configure i/f up for IPv6 */
 int  sif6down(int);	/* Configure i/f down for IPv6 */
 int  sif6addr(int, eui64_t, eui64_t);

--- a/pppd/sys-linux.c
+++ b/pppd/sys-linux.c
@@ -3147,54 +3147,6 @@ sys_check_options(void)
     return 1;
 }
 
-#ifdef INET6
-/*
- * ether_to_eui64 - Convert 48-bit Ethernet address into 64-bit EUI
- *
- * convert the 48-bit MAC address of eth0 into EUI 64. caller also assumes
- * that the system has a properly configured Ethernet interface for this
- * function to return non-zero.
- */
-int
-ether_to_eui64(eui64_t *p_eui64)
-{
-    struct ifreq ifr;
-    int skfd;
-    const unsigned char *ptr;
-
-    skfd = socket(PF_INET6, SOCK_DGRAM, 0);
-    if(skfd == -1)
-    {
-        warn("could not open IPv6 socket");
-        return 0;
-    }
-
-    strcpy(ifr.ifr_name, "eth0");
-    if(ioctl(skfd, SIOCGIFHWADDR, &ifr) < 0)
-    {
-        close(skfd);
-        warn("could not obtain hardware address for eth0");
-        return 0;
-    }
-    close(skfd);
-
-    /*
-     * And convert the EUI-48 into EUI-64, per RFC 2472 [sec 4.1]
-     */
-    ptr = (unsigned char *) ifr.ifr_hwaddr.sa_data;
-    p_eui64->e8[0] = ptr[0] | 0x02;
-    p_eui64->e8[1] = ptr[1];
-    p_eui64->e8[2] = ptr[2];
-    p_eui64->e8[3] = 0xFF;
-    p_eui64->e8[4] = 0xFE;
-    p_eui64->e8[5] = ptr[3];
-    p_eui64->e8[6] = ptr[4];
-    p_eui64->e8[7] = ptr[5];
-
-    return 1;
-}
-#endif
-
 /********************************************************************
  *
  * get_time - Get current time, monotonic if possible.

--- a/pppd/sys-solaris.c
+++ b/pppd/sys-solaris.c
@@ -531,50 +531,6 @@ slifname_done:
 
 
 }
-
-
-/*
- * ether_to_eui64 - Convert 48-bit Ethernet address into 64-bit EUI
- *
- * walks the list of valid ethernet interfaces, and convert the first
- * found 48-bit MAC address into EUI 64. caller also assumes that
- * the system has a properly configured Ethernet interface for this
- * function to return non-zero.
- */
-int
-ether_to_eui64(eui64_t *p_eui64)
-{
-    struct sockaddr s_eth_addr;
-    struct ether_addr *eth_addr = (struct ether_addr *)&s_eth_addr.sa_data;
-    char *if_name;
-
-    if ((if_name = get_first_ethernet()) == NULL) {
-	error("no persistent id can be found");
-	return 0;
-    }
- 
-    /*
-     * Send DL_INFO_REQ to the driver to solicit its MAC address
-     */
-    if (!get_hw_addr_dlpi(if_name, &s_eth_addr)) {
-	error("could not obtain hardware address for %s", if_name);
-	return 0;
-    }
-
-    /*
-     * And convert the EUI-48 into EUI-64, per RFC 2472 [sec 4.1]
-     */
-    p_eui64->e8[0] = (eth_addr->ether_addr_octet[0] & 0xFF) | 0x02;
-    p_eui64->e8[1] = (eth_addr->ether_addr_octet[1] & 0xFF);
-    p_eui64->e8[2] = (eth_addr->ether_addr_octet[2] & 0xFF);
-    p_eui64->e8[3] = 0xFF;
-    p_eui64->e8[4] = 0xFE;
-    p_eui64->e8[5] = (eth_addr->ether_addr_octet[3] & 0xFF);
-    p_eui64->e8[6] = (eth_addr->ether_addr_octet[4] & 0xFF);
-    p_eui64->e8[7] = (eth_addr->ether_addr_octet[5] & 0xFF);
-
-    return 1;
-}
 #endif /* defined(SOL2) && defined(INET6) */
 
 /*


### PR DESCRIPTION
Now when get_first_ethernet() is implemented for both Linux and Solaris,
implementation of ether_to_eui64() function can use this function
get_first_ethernet() and therefore be system independent.

So change implementation of ether_to_eui64() to use get_first_ethernet()
function and move it from Linux and Solaris files to common ipv6cp.c file
where it is used.