### PR TITLE
Fix ether_to_eui64() to prefer devnam ether interface

### DIFF
--- a/pppd/ipv6cp.c
+++ b/pppd/ipv6cp.c
@@ -1058,7 +1058,8 @@ endswitch:
 /*
  * ether_to_eui64 - Convert 48-bit Ethernet address into 64-bit EUI
  *
- * walks the list of valid ethernet interfaces, and convert the first
+ * walks the list of valid ethernet interfaces, starting with devnam
+ * (for PPPoE it is ethernet interface), and convert the first
  * found 48-bit MAC address into EUI 64. caller also assumes that
  * the system has a properly configured Ethernet interface for this
  * function to return non-zero.
@@ -1069,14 +1070,16 @@ ether_to_eui64(eui64_t *p_eui64)
     u_char addr[6];
     char *if_name;
 
-    if ((if_name = get_first_ethernet()) == NULL) {
-        error("no persistent id can be found");
-        return 0;
-    }
+    if (get_if_hwaddr(addr, devnam) < 0) {
+        if ((if_name = get_first_ethernet()) == NULL) {
+            error("no persistent id can be found");
+            return 0;
+        }
 
-    if (get_if_hwaddr(addr, if_name) < 0) {
-        error("could not obtain hardware address for %s", if_name);
-        return 0;
+        if (get_if_hwaddr(addr, if_name) < 0) {
+            error("could not obtain hardware address for %s", if_name);
+            return 0;
+        }
     }
 
     /*


### PR DESCRIPTION
In case of PPPoE connection, devnam is ethernet interface. So in this case
calculate EUI-64 IPV6CP identifier from the PPPoE ethernet interface
instead from the first ethernet interface in the system.

This would ensure that each PPPoE connection would have unique IPv6 link
local address calculated from the interface MAC address on which is PPPoE
going to be established.

Currently IPv6 link local address is always calculated from the MAC address
of the first ethernet interface and therefore all active PPPoE connections
have by default same (non unique) IPv6 link local address.