### PR TITLE
Fix for issue #137: Allow auth-up-notifier even if 'noauth' is specified

### DIFF
--- a/pppd/auth.c
+++ b/pppd/auth.c
@@ -876,8 +876,8 @@ network_phase(int unit)
     /*
      * If the peer had to authenticate, run the auth-up script now.
      */
+    notify(auth_up_notifier, 0);
     if (go->neg_chap || go->neg_upap || go->neg_eap) {
-	notify(auth_up_notifier, 0);
 	auth_state = s_up;
 	if (auth_script_state == s_down && auth_script_pid == 0) {
 	    auth_script_state = s_up;


### PR DESCRIPTION
This will allow client side plug-ins like for SSTP to run the auth-up-notifier hook to
process the authentication complete step. This will aid in inspection of the mppe keys 
before the network phase is initiated.

Signed-off-by: Eivind Naess <eivnaes@yahoo.com>