### PR TITLE
pppd to send nak suggesting eap-mschapv2 when using eap-tls

### DIFF
--- a/pppd/eap.c
+++ b/pppd/eap.c
@@ -1951,7 +1951,7 @@ eap_request(eap_state *esp, u_char *inp, int id, int len)
 			break;
 
 		default:
-			eap_send_nak(esp, id, EAPT_TLS);
+			eap_send_nak(esp, id, EAPT_MSCHAPV2);
 			esp->es_client.ea_using_eaptls = 0;
 			break;
 		}


### PR DESCRIPTION
A simple fix for issue #210 

The algorithm selection is currently implemented inline with the currently attempted algorithm. While RFC3748 allows for sending multiple algorithms as a part of the NAK response. Microsoft will terminate the connection when the first suggested algorithm isn't supported. Currently, EAP-TLS will suggest EAP-MSCHAPV2, which will suggest EAP-SRP, which will suggest EAP-CHAPMD5. 

Signed-off-by: Eivind Naess <eivnaes@yahoo.com>