### PR TITLE
Install with standard permissions

### DIFF
--- a/pppd/Makefile.linux
+++ b/pppd/Makefile.linux
@@ -239,10 +239,10 @@ all: $(TARGETS)
 install: pppd
 	mkdir -p $(BINDIR) $(MANDIR)
 	$(EXTRAINSTALL)
-	$(INSTALL) -c -m 555 pppd $(BINDIR)/pppd
+	$(INSTALL) -c -m 755 pppd $(BINDIR)/pppd
 	if chgrp pppusers $(BINDIR)/pppd 2>/dev/null; then \
 	  chmod o-rx,u+s $(BINDIR)/pppd; fi
-	$(INSTALL) -c -m 444 pppd.8 $(MANDIR)
+	$(INSTALL) -c -m 644 pppd.8 $(MANDIR)
 
 pppd: $(PPPDOBJS)
 	$(CC) $(CFLAGS) $(LDFLAGS) $(LDFLAGS_PLUGIN) -o pppd $(PPPDOBJS) $(LIBS)

--- a/pppd/plugins/pppoatm/Makefile.linux
+++ b/pppd/plugins/pppoatm/Makefile.linux
@@ -38,7 +38,7 @@ $(PLUGIN): $(PLUGIN_OBJS)
 
 install: all
 	$(INSTALL) -d -m 755 $(LIBDIR)
-	$(INSTALL) -c -m 4550 $(PLUGIN) $(LIBDIR)
+	$(INSTALL) -c -m 755 $(PLUGIN) $(LIBDIR)
 
 clean:
 	rm -f *.o *.so

--- a/pppd/plugins/pppoe/Makefile.linux
+++ b/pppd/plugins/pppoe/Makefile.linux
@@ -42,11 +42,11 @@ pppoe.so: plugin.o discovery.o if.o common.o
 
 install: all
 	$(INSTALL) -d -m 755 $(LIBDIR)
-	$(INSTALL) -c -m 4550 pppoe.so $(LIBDIR)
+	$(INSTALL) -c -m 755 pppoe.so $(LIBDIR)
 	# Symlink for backward compatibility
 	$(LN_S) pppoe.so $(LIBDIR)/rp-pppoe.so
 	$(INSTALL) -d -m 755 $(BINDIR)
-	$(INSTALL) -c -m 555 pppoe-discovery $(BINDIR)
+	$(INSTALL) -c -m 755 pppoe-discovery $(BINDIR)
 
 clean:
 	rm -f *.o *.so pppoe-discovery


### PR DESCRIPTION
Is there reason for non standard permissions? In Fedora it's installed
with standard permissions for years.

Signed-off-by: Jaroslav Škarvada <jskarvad@redhat.com>