### PR TITLE
Fix nosendip option

### DIFF
--- a/pppd/ipcp.c
+++ b/pppd/ipcp.c
@@ -994,6 +994,7 @@ bad:
 static int
 ipcp_nakci(fsm *f, u_char *p, int len, int treat_as_reject)
 {
+    ipcp_options *wo = &ipcp_wantoptions[f->unit];
     ipcp_options *go = &ipcp_gotoptions[f->unit];
     u_char cimaxslotindex, cicflag;
     u_char citype, cilen, *next;
@@ -1169,7 +1170,7 @@ ipcp_nakci(fsm *f, u_char *p, int len, int treat_as_reject)
 	    GETLONG(l, p);
 	    ciaddr1 = htonl(l);
 	    if (ciaddr1 && go->accept_local)
-		try.ouraddr = ciaddr1;
+		try.ouraddr = wo->old_addrs ? ciaddr1 : 0;
 	    GETLONG(l, p);
 	    ciaddr2 = htonl(l);
 	    if (ciaddr2 && go->accept_remote)
@@ -1184,7 +1185,7 @@ ipcp_nakci(fsm *f, u_char *p, int len, int treat_as_reject)
 	    ciaddr1 = htonl(l);
 	    if (ciaddr1 && go->accept_local)
 		try.ouraddr = ciaddr1;
-	    if (try.ouraddr != 0)
+	    if (try.ouraddr != 0 && wo->neg_addr)
 		try.neg_addr = 1;
 	    no.neg_addr = 1;
 	    break;
@@ -1470,7 +1471,7 @@ ipcp_reqci(fsm *f, u_char *inp,	int *len, int reject_if_disagree)
 	    if (ciaddr2 != wo->ouraddr) {
 		if (ciaddr2 == 0 || !wo->accept_local) {
 		    orc = CONFNAK;
-		    if (!reject_if_disagree) {
+		    if (!reject_if_disagree && wo->old_addrs) {
 			DECPTR(sizeof(u_int32_t), p);
 			tl = ntohl(wo->ouraddr);
 			PUTLONG(tl, p);


### PR DESCRIPTION
Respect nosendip option and do not send our IP address to peer even when
peer send to us IPCP ConfNak packet with address 0.0.0.0.

Without this patch pppd sends own local IP address to remote peer and it
can be reproduced with following command:

    $ ./pppd/pppd debug local noauth nolock nodetach asyncmap 0 default-asyncmap novj noaccomp nopcomp nodeflate nobsdcomp noipv6 nodefaultroute noipdefault pty "./pppd/pppd debug local noauth nolock nodetach asyncmap 0 default-asyncmap novj noaccomp nopcomp nodeflate nobsdcomp noipv6 nodefaultroute nosendip 10.0.0.1:10.0.0.2 notty"

Without this patch first pppd receives 10.0.0.1 address from second pppd
even second pppd is configured to not send its IP address.

    rcvd [LCP ConfReq id=0x1 <magic 0x7cf29fab>]
    sent [LCP ConfReq id=0x1 <magic 0x4550b00c>]
    sent [LCP ConfAck id=0x1 <magic 0x7cf29fab>]
    rcvd [LCP ConfAck id=0x1 <magic 0x4550b00c>]
    sent [LCP EchoReq id=0x0 magic=0x4550b00c]
    sent [IPCP ConfReq id=0x1 <addr 0.0.0.0>]
    rcvd [LCP EchoReq id=0x0 magic=0x7cf29fab]
    sent [LCP EchoRep id=0x0 magic=0x4550b00c]
    rcvd [IPCP ConfReq id=0x1]
    sent [IPCP ConfNak id=0x1 <addr 0.0.0.0>]
    rcvd [LCP EchoRep id=0x0 magic=0x7cf29fab]
    rcvd [IPCP ConfNak id=0x1 <addr 10.0.0.2>]
    sent [IPCP ConfReq id=0x2 <addr 10.0.0.2>]
    rcvd [IPCP ConfReq id=0x2 <addr 10.0.0.1>]
    sent [IPCP ConfAck id=0x2 <addr 10.0.0.1>]
    rcvd [IPCP ConfAck id=0x2 <addr 10.0.0.2>]
    local  IP address 10.0.0.2
    remote IP address 10.0.0.1

After applying this patch first pppd does not receive remote 10.0.0.1
address anymore which can be seen by the fact that first pppd cannot
determinate remote IP address and defaulting to 10.64.64.64.

    rcvd [LCP ConfReq id=0x1 <magic 0x1da305a6>]
    sent [LCP ConfReq id=0x1 <magic 0x2d76359>]
    sent [LCP ConfAck id=0x1 <magic 0x1da305a6>]
    rcvd [LCP ConfAck id=0x1 <magic 0x2d76359>]
    sent [LCP EchoReq id=0x0 magic=0x2d76359]
    sent [IPCP ConfReq id=0x1 <addr 0.0.0.0>]
    rcvd [LCP EchoReq id=0x0 magic=0x1da305a6]
    sent [LCP EchoRep id=0x0 magic=0x2d76359]
    rcvd [IPCP ConfReq id=0x1]
    sent [IPCP ConfNak id=0x1 <addr 0.0.0.0>]
    rcvd [LCP EchoRep id=0x0 magic=0x1da305a6]
    rcvd [IPCP ConfNak id=0x1 <addr 10.0.0.2>]
    sent [IPCP ConfReq id=0x2 <addr 10.0.0.2>]
    rcvd [IPCP ConfReq id=0x2]
    sent [IPCP ConfAck id=0x2]
    rcvd [IPCP ConfAck id=0x2 <addr 10.0.0.2>]
    Could not determine remote IP address: defaulting to 10.64.64.64
    local  IP address 10.0.0.2
    remote IP address 10.64.64.64