### PR TITLE
Fix demand mode with noremoteip option

### DIFF
--- a/pppd/ipcp.c
+++ b/pppd/ipcp.c
@@ -1822,9 +1822,10 @@ ipcp_up(fsm *f)
 		wo->ouraddr = go->ouraddr;
 	    } else
 		script_unsetenv("OLDIPLOCAL");
-	    if (ho->hisaddr != wo->hisaddr && wo->hisaddr != 0) {
+	    if (ho->hisaddr != wo->hisaddr) {
 		warn("Remote IP address changed to %I", ho->hisaddr);
-		script_setenv("OLDIPREMOTE", ip_ntoa(wo->hisaddr), 0);
+		if (wo->hisaddr != 0)
+		    script_setenv("OLDIPREMOTE", ip_ntoa(wo->hisaddr), 0);
 		wo->hisaddr = ho->hisaddr;
 	    } else
 		script_unsetenv("OLDIPREMOTE");


### PR DESCRIPTION
When noremoteip is set then initial hisaddr (peer address) is zero. So to
handle setting correct peer address after establishing connection it is
needed to change logic around 'wo->hisaddr != 0' condition. wo->hisaddr
needs to be updated from initial zero address to correct peer address.