### PR TITLE
pppd/Makefile.linux: Fix copy/paste typo

### DIFF
--- a/pppd/Makefile.linux
+++ b/pppd/Makefile.linux
@@ -144,7 +144,7 @@ CFLAGS   += -DHAS_SHADOW
 #LIBS     += -lshadow $(LIBS)
 endif
 
-CRYPTHEADER = "\#include <utmp.h>"
+CRYPTHEADER = "\#include <crypt.h>"
 ifeq ($(shell echo $(CRYPTHEADER) | $(CC) -E - >/dev/null 2>&1 && echo yes),yes)
 CFLAGS  += -DHAVE_CRYPT_H=1
 LIBS	+= -lcrypt


### PR DESCRIPTION
A previous commit to fix a make issue had a copy/paste error, fix it
to refer to the correct header.

Signed-off-by: Richard Purdie <richard.purdie@linuxfoundation.org>