### PR TITLE
ipv6cp: Fix demand mode for IPv6

### DIFF
--- a/pppd/ipv6cp.c
+++ b/pppd/ipv6cp.c
@@ -528,7 +528,8 @@ ipv6cp_resetci(fsm *f)
     
     if (!wo->opt_local) {
 	wo->accept_local = 1;
-	eui64_magic_nz(wo->ourid);
+	if (!demand)
+	    eui64_magic_nz(wo->ourid);
     }
     if (!wo->opt_remote)
 	wo->accept_remote = 1;
@@ -1140,11 +1141,6 @@ ipv6_check_options(void)
 		wo->opt_remote = 1;
 	}
     }
-
-    if (demand && (eui64_iszero(wo->ourid) || eui64_iszero(wo->hisid))) {
-	option_error("local/remote LL address required for demand-dialling\n");
-	exit(EXIT_OPTION_ERROR);
-    }
 }
 
 
@@ -1156,6 +1152,15 @@ static int
 ipv6_demand_conf(int u)
 {
     ipv6cp_options *wo = &ipv6cp_wantoptions[u];
+
+    if (eui64_iszero(wo->hisid)) {
+	/* make up an arbitrary identifier for the peer */
+	eui64_magic_nz(wo->hisid);
+    }
+    if (eui64_iszero(wo->ourid)) {
+	/* make up an arbitrary identifier for us */
+	eui64_magic_nz(wo->ourid);
+    }
 
     if (!sif6up(u))
 	return 0;

--- a/pppd/ipv6cp.c
+++ b/pppd/ipv6cp.c
@@ -1243,7 +1243,7 @@ ipv6cp_up(fsm *f)
 	    if (! eui64_equals(ho->hisid, wo->hisid))
 		warn("Remote LL address changed to %s", 
 		     llv6_ntoa(ho->hisid));
-	    ipv6cp_clear_addrs(f->unit, go->ourid, ho->hisid);
+	    ipv6cp_clear_addrs(f->unit, wo->ourid, wo->hisid);
 
 	    /* Set the interface to the new addresses */
 	    if (!sif6addr(f->unit, go->ourid, ho->hisid)) {

--- a/pppd/ipv6cp.c
+++ b/pppd/ipv6cp.c
@@ -1176,7 +1176,6 @@ ipv6_demand_conf(int u)
 	if (sif6defaultroute(u, wo->ourid, wo->hisid))
 	    default_route_set[u] = 1;
 
-    notice("ipv6_demand_conf");
     notice("local  LL address %s", llv6_ntoa(wo->ourid));
     notice("remote LL address %s", llv6_ntoa(wo->hisid));
 


### PR DESCRIPTION
* ipv6cp: Allow to use demand mode without specifying IPv6 address/identifier
* ipv6cp: Fix clearing previous IPv6 LL address in demand mode
* ipv6cp: Remove demand debug notice