### PR TITLE
ipv6cp: Fix ipv6cp-use-persistent option

### DIFF
--- a/pppd/ipv6cp.c
+++ b/pppd/ipv6cp.c
@@ -1069,7 +1069,7 @@ ether_to_eui64(eui64_t *p_eui64)
 {
     u_char addr[6];
 
-    if (get_if_hwaddr(addr, devnam) < 0 || get_first_ether_hwaddr(addr) < 0) {
+    if (get_if_hwaddr(addr, devnam) < 0 && get_first_ether_hwaddr(addr) < 0) {
         error("ipv6cp: no persistent id can be found");
         return 0;
     }


### PR DESCRIPTION
There is incorrect logic in ether_to_eui64() function. Persistent id cannot
be found when both sources of persistent id fails, not just one.

This fixes ipv6cp-use-persistent option for non-ethernet PPP connections.

Fixes: 952cfa5acc41ad4ceee160420a188a388bb340cf