### PR TITLE
ipv6cp: Fix ipv6cp-use-persistent option when remote address is specified

### DIFF
--- a/pppd/ipv6cp.c
+++ b/pppd/ipv6cp.c
@@ -1106,7 +1106,7 @@ ipv6_check_options(void)
      * Persistent link-local id is only used when user has not explicitly
      * configure/hard-code the id
      */
-    if ((wo->use_persistent) && (!wo->opt_local) && (!wo->opt_remote)) {
+    if ((wo->use_persistent) && (!wo->opt_local)) {
 
 	/* 
 	 * On systems where there are no Ethernet interfaces used, there


### PR DESCRIPTION
Option ipv6cp-use-persistent affects only local interface identifier (local
link-local address). It does not affects remote peer interface identifier
(and remote link-local address) therefore ipv6cp-use-persistent option
should not depend on remote address.