### PR TITLE
Minor cleanup to make use of the eui64_magic_nz() macro

### DIFF
--- a/pppd/ipv6cp.c
+++ b/pppd/ipv6cp.c
@@ -1129,9 +1129,8 @@ ipv6_check_options(void)
 	    if (!eui64_iszero(wo->ourid))
 		wo->opt_local = 1;
 	}
-	
-	while (eui64_iszero(wo->ourid))
-	    eui64_magic(wo->ourid);
+
+	eui64_magic_nz(wo->ourid);
     }
 
     if (!wo->opt_remote) {


### PR DESCRIPTION
`eui64_magic_nz()` is functionality equivalent to `while (eui64_iszero(wo->ourid))  eui64_magic(wo->ourid);` and is used everywhere else in `ipv6cp.c`.